### PR TITLE
Fix old recipe path in editor

### DIFF
--- a/Brewpad/Views/RecipeEditorView.swift
+++ b/Brewpad/Views/RecipeEditorView.swift
@@ -238,8 +238,8 @@ struct RecipeEditorView: View {
                 // If we're editing and the name changed, delete the old file
                 if let oldRecipe = existingRecipe,
                    oldRecipe.name != recipe.name {
-                    let oldFilename = oldRecipe.name.lowercased().replacingOccurrences(of: " ", with: "_")
-                    let oldFileURL = recipesDirectory.appendingPathComponent("\(oldFilename).json")
+                    let oldFilename = generateFilename(for: oldRecipe)
+                    let oldFileURL = recipesDirectory.appendingPathComponent(oldFilename)
                     if FileManager.default.fileExists(atPath: oldFileURL.path) {
                         try FileManager.default.removeItem(at: oldFileURL)
                         print("🗑️ Deleted old recipe file: \(oldFileURL.path)")


### PR DESCRIPTION
## Summary
- ensure RecipeEditorView removes the correct file when overwriting a recipe

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684022209ac0832aa32e1e86ab95f17e