### PR TITLE
Add basic MeasurementConverter unit tests

### DIFF
--- a/BrewpadTests/MeasurementConverterTests.swift
+++ b/BrewpadTests/MeasurementConverterTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import Brewpad
+
+struct MeasurementConverterTests {
+    @Test
+    func testGramsToOunces() async throws {
+        let result = MeasurementConverter.convert("20g", toImperial: true)
+        #expect(result.contains("0.7 oz"))
+    }
+
+    @Test
+    func testMillilitersToFluidOunces() async throws {
+        let result = MeasurementConverter.convert("120ml", toImperial: true)
+        #expect(result.contains("4.1 fl oz"))
+    }
+
+    @Test
+    func testCelsiusToFahrenheit() async throws {
+        let result = MeasurementConverter.convert("93°C", toImperial: true)
+        #expect(result.contains("199°F"))
+    }
+
+    @Test
+    func testCentimetersToInches() async throws {
+        let result = MeasurementConverter.convert("20cm", toImperial: true)
+        #expect(result.contains("7.9 inches"))
+    }
+}


### PR DESCRIPTION
## Summary
- add a new test suite `MeasurementConverterTests` verifying imperial conversions

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840242e2e8c832a8875ee9a465cdbbf