### PR TITLE
Add Holiday theme unit tests

### DIFF
--- a/BrewpadTests/HolidayThemeTests.swift
+++ b/BrewpadTests/HolidayThemeTests.swift
@@ -1,0 +1,35 @@
+import Testing
+import SwiftUI
+@testable import Brewpad
+
+struct HolidayThemeTests {
+    @Test
+    func testValentinesColor() async throws {
+        let color = HolidayTheme.getColor(for: .valentines)
+        #expect(color == .pink)
+    }
+
+    @Test
+    func testChristmasColor() async throws {
+        let color = HolidayTheme.getColor(for: .christmasDay)
+        #expect(color == .red)
+    }
+
+    @Test
+    func testHalloweenColor() async throws {
+        let color = HolidayTheme.getColor(for: .halloween)
+        #expect(color == .orange)
+    }
+
+    @Test
+    func testThanksgivingColor() async throws {
+        let color = HolidayTheme.getColor(for: .thanksgiving)
+        #expect(color == .brown)
+    }
+
+    @Test
+    func testEasterColor() async throws {
+        let color = HolidayTheme.getColor(for: .easter)
+        #expect(color == .purple)
+    }
+}


### PR DESCRIPTION
## Summary
- add new `HolidayThemeTests` to verify color mappings

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684025611c5c832aa8edc726d22657a1