### PR TITLE
Fix recipe card layering

### DIFF
--- a/Brewpad/Views/RecipeCard.swift
+++ b/Brewpad/Views/RecipeCard.swift
@@ -106,6 +106,7 @@ struct RecipeCard: View {
                 }
             }
         }
+        .zIndex(isExpanded ? 1 : 0)
         .sheet(isPresented: $showingNoteSheet) {
             AddNoteView(recipe: recipe)
         }

--- a/Brewpad/Views/RecipesView.swift
+++ b/Brewpad/Views/RecipesView.swift
@@ -83,6 +83,7 @@ struct RecipesView: View {
         slideDirection = newIndex > selectedCategory ? .right : .left
         withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
             selectedCategory = newIndex
+            expandedRecipe = nil
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
             slideDirection = .none


### PR DESCRIPTION
## Summary
- avoid overlay of collapsed recipes by assigning a z-index to expanded cards
- reset expanded cards when switching categories

## Testing
- `swift test -c debug` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68402a9c50e8832aafcf49791d3ccba7