### PR TITLE
Fix recipe card layering

### DIFF
--- a/Brewpad/Views/RecipeCard.swift
+++ b/Brewpad/Views/RecipeCard.swift
@@ -15,59 +15,7 @@ struct RecipeCard: View {
     private let expandedHeight: CGFloat = 300
     
     var body: some View {
-        ZStack(alignment: .top) {
-            if isExpanded {
-                VStack(spacing: 0) {
-                    Spacer(minLength: 70)
-                    
-                    TabView(selection: $selectedSection) {
-                        ScrollView {
-                            descriptionView
-                        }
-                        .tag(0)
-                        
-                        ScrollView {
-                            ingredientsView
-                        }
-                        .tag(1)
-                        
-                        ScrollView {
-                            preparationView
-                        }
-                        .tag(2)
-                        
-                        ScrollView {
-                            notesView
-                        }
-                        .tag(3)
-                    }
-                    .tabViewStyle(.page(indexDisplayMode: .never))
-                    .frame(height: expandedHeight)
-                    
-                    HStack(spacing: 8) {
-                        ForEach(0..<4) { index in
-                            Circle()
-                                .fill(selectedSection == index ? Color.blue : Color.gray.opacity(0.3))
-                                .frame(width: 6, height: 6)
-                        }
-                    }
-                    .padding(.vertical, 8)
-                }
-                .frame(maxWidth: .infinity)
-                .background(Color.gray.opacity(0.05))
-                .cornerRadius(10)
-                .transition(
-                    .asymmetric(
-                        insertion: .move(edge: .top)
-                            .combined(with: .opacity)
-                            .animation(.spring(response: 0.35, dampingFraction: 0.7)),
-                        removal: .move(edge: .top)
-                            .combined(with: .opacity)
-                            .animation(.spring(response: 0.3, dampingFraction: 0.8))
-                    )
-                )
-            }
-            
+        VStack(spacing: 0) {
             Button(action: onTap) {
                 HStack {
                     VStack(alignment: .leading) {
@@ -105,7 +53,52 @@ struct RecipeCard: View {
                     }
                 }
             }
+
+            VStack(spacing: 0) {
+                Spacer(minLength: 70)
+
+                TabView(selection: $selectedSection) {
+                    ScrollView {
+                        descriptionView
+                    }
+                    .tag(0)
+
+                    ScrollView {
+                        ingredientsView
+                    }
+                    .tag(1)
+
+                    ScrollView {
+                        preparationView
+                    }
+                    .tag(2)
+
+                    ScrollView {
+                        notesView
+                    }
+                    .tag(3)
+                }
+                .tabViewStyle(.page(indexDisplayMode: .never))
+                .frame(height: expandedHeight)
+
+                HStack(spacing: 8) {
+                    ForEach(0..<4) { index in
+                        Circle()
+                            .fill(selectedSection == index ? Color.blue : Color.gray.opacity(0.3))
+                            .frame(width: 6, height: 6)
+                    }
+                }
+                .padding(.vertical, 8)
+            }
+            .frame(maxWidth: .infinity)
+            .background(Color.gray.opacity(0.05))
+            .cornerRadius(10)
+            .frame(height: isExpanded ? expandedHeight + 100 : 0)
+            .clipped()
+            .opacity(isExpanded ? 1 : 0)
         }
+        .zIndex(isExpanded ? 1 : 0)
+        .animation(.spring(response: 0.35, dampingFraction: 0.8), value: isExpanded)
         .sheet(isPresented: $showingNoteSheet) {
             AddNoteView(recipe: recipe)
         }

--- a/Brewpad/Views/RecipesView.swift
+++ b/Brewpad/Views/RecipesView.swift
@@ -83,6 +83,7 @@ struct RecipesView: View {
         slideDirection = newIndex > selectedCategory ? .right : .left
         withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
             selectedCategory = newIndex
+            expandedRecipe = nil
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
             slideDirection = .none


### PR DESCRIPTION
## Summary
- avoid overlay of collapsed recipes by assigning a z-index to expanded cards
- reset expanded cards when switching categories
- refactor the recipe card animation to animate height instead of using a transition

## Testing
- `swift test -c debug` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68402a9c50e8832aafcf49791d3ccba7