### PR TITLE
Change startup tab to Recipes

### DIFF
--- a/Brewpad/ContentView.swift
+++ b/Brewpad/ContentView.swift
@@ -11,7 +11,8 @@ struct ContentView: View {
     @EnvironmentObject private var settingsManager: SettingsManager
     @EnvironmentObject private var recipeStore: RecipeStore
     @EnvironmentObject private var appState: AppState
-    @State private var selectedTab = 0
+    // Start the app on the Recipes tab instead of Featured
+    @State private var selectedTab = 1
     
     var body: some View {
         Group {


### PR DESCRIPTION
## Summary
- start the app on the Recipes tab instead of Featured

## Testing
- `swift test -list-tests` *(fails: Missing value for '-s <specifier>')*
- `xcodebuild -list -project Brewpad.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403c89a410832ab6a06d4a8f1b5cd5