### PR TITLE
Add server check and protect Brewpad recipes

### DIFF
--- a/Brewpad/ContentView.swift
+++ b/Brewpad/ContentView.swift
@@ -70,6 +70,11 @@ struct ContentView: View {
         }
         .animation(.easeInOut(duration: 0.3), value: recipeStore.isInitialized)
         .animation(.easeInOut(duration: 0.3), value: settingsManager.hasCompletedOnboarding)
+        .alert("Server Not Reachable", isPresented: $recipeStore.showServerError) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text("Unable to reach the Brewpad recipe server.")
+        }
     }
 }
 

--- a/Brewpad/Views/RecipeCard.swift
+++ b/Brewpad/Views/RecipeCard.swift
@@ -98,7 +98,7 @@ struct RecipeCard: View {
                 .cornerRadius(10)
             }
             .contextMenu {
-                if !recipe.isBuiltIn { // Only show delete for user-created recipes
+                if !recipe.isBuiltIn && recipe.creator != "Brewpad" {
                     Button(role: .destructive) {
                         print("🗑️ Delete button tapped for recipe: \(recipe.name)")
                         showingDeleteConfirmation = true

--- a/Brewpad/Views/RecipeManagerView.swift
+++ b/Brewpad/Views/RecipeManagerView.swift
@@ -345,11 +345,13 @@ struct RecipeListView: View {
                     }
                 }
                 .contextMenu {
-                    Button(role: .destructive) {
-                        recipeToDelete = recipe
-                        showingDeleteConfirmation = true
-                    } label: {
-                        Label("Delete Recipe", systemImage: "trash")
+                    if !recipe.isBuiltIn && recipe.creator != "Brewpad" {
+                        Button(role: .destructive) {
+                            recipeToDelete = recipe
+                            showingDeleteConfirmation = true
+                        } label: {
+                            Label("Delete Recipe", systemImage: "trash")
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- check recipe server reachability on startup
- show error alert when server cannot be reached
- prevent deletion of recipes published by Brewpad

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68404074d7f8832ab8e064541e7d65f4