### PR TITLE
Add server response debug info

### DIFF
--- a/Brewpad/Views/RecipeDebugView.swift
+++ b/Brewpad/Views/RecipeDebugView.swift
@@ -40,6 +40,19 @@ struct RecipeDebugView: View {
                         .padding(.vertical, 4)
                     }
                 }
+
+                // Server Response Section
+                Section("Server Response") {
+                    if let response = recipeStore.serverResponse {
+                        Text(response)
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                    } else {
+                        Text("No response yet")
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                    }
+                }
             }
             .navigationTitle("Recipe Debug Info")
             .navigationBarTitleDisplayMode(.inline)
@@ -49,6 +62,9 @@ struct RecipeDebugView: View {
                         dismiss()
                     }
                 }
+            }
+            .onAppear {
+                recipeStore.checkServerConnection()
             }
         }
     }


### PR DESCRIPTION
## Summary
- capture server response status and body in `RecipeStore`
- show server response in new section of `RecipeDebugView`
- trigger server check when opening debug view

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684041fd1bcc832a98cf584a3a999cd3