### PR TITLE
Add server response debug info

### DIFF
--- a/Brewpad/Views/RecipeDebugView.swift
+++ b/Brewpad/Views/RecipeDebugView.swift
@@ -40,6 +40,19 @@ struct RecipeDebugView: View {
                         .padding(.vertical, 4)
                     }
                 }
+
+                // Server Response Section
+                Section("Server Response") {
+                    if let response = recipeStore.serverResponse {
+                        Text(response)
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                    } else {
+                        Text("No response yet")
+                            .font(.caption)
+                            .foregroundColor(.gray)
+                    }
+                }
             }
             .navigationTitle("Recipe Debug Info")
             .navigationBarTitleDisplayMode(.inline)
@@ -49,6 +62,9 @@ struct RecipeDebugView: View {
                         dismiss()
                     }
                 }
+            }
+            .onAppear {
+                recipeStore.checkServerConnection()
             }
         }
     }

--- a/Brewpad/Views/SettingsView.swift
+++ b/Brewpad/Views/SettingsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @EnvironmentObject private var settingsManager: SettingsManager
+    @EnvironmentObject private var recipeStore: RecipeStore
     @State private var isDownloading = false
     @State private var showDownloadComplete = false
     @State private var isEditingUsername = false
@@ -284,12 +285,40 @@ struct SettingsView: View {
                                             .foregroundColor(.gray)
                                     }
                                 }
-                                
+
                                 Text("View detailed recipe information")
                                     .font(.caption)
                                     .foregroundColor(.gray)
                             }
-                            
+
+                            // Server Response
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text("Server Response")
+                                    .font(.headline)
+
+                                if let response = recipeStore.serverResponse {
+                                    Text(response)
+                                        .font(.caption)
+                                        .foregroundColor(.gray)
+                                } else {
+                                    Text("No response yet")
+                                        .font(.caption)
+                                        .foregroundColor(.gray)
+                                }
+
+                                Button(action: { recipeStore.checkServerConnection() }) {
+                                    HStack {
+                                        Image(systemName: "arrow.clockwise.circle.fill")
+                                        Text("Check Server Connection")
+                                    }
+                                    .foregroundColor(.white)
+                                    .frame(maxWidth: .infinity)
+                                    .padding()
+                                    .background(Color.blue)
+                                    .cornerRadius(10)
+                                }
+                            }
+
                             Divider()
                         }
                     }


### PR DESCRIPTION
## Summary
- show the last server response in Debug Settings
- provide button to check server connection manually
- expose `RecipeStore` in `SettingsView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684041fd1bcc832a98cf584a3a999cd3