### PR TITLE
Display only server status code

### DIFF
--- a/Brewpad/Models/RecipeStore.swift
+++ b/Brewpad/Models/RecipeStore.swift
@@ -36,17 +36,11 @@ class RecipeStore: ObservableObject {
     func checkServerConnection() {
         guard let url = URL(string: "https://bprs.mirreravencd.com") else { return }
 
-        URLSession.shared.dataTask(with: url) { data, response, error in
+        URLSession.shared.dataTask(with: url) { _, response, error in
             DispatchQueue.main.async {
                 if let httpResponse = response as? HTTPURLResponse {
                     let statusCode = httpResponse.statusCode
-                    var message = "Status: \(statusCode)"
-                    if let data = data,
-                       let body = String(data: data, encoding: .utf8),
-                       !body.isEmpty {
-                        message += "\n\n" + body
-                    }
-                    self.serverResponse = message
+                    self.serverResponse = "Status: \(statusCode)"
                     self.showServerError = !(200...299).contains(statusCode) || error != nil
                 } else if let error = error {
                     self.serverResponse = "Error: \(error.localizedDescription)"


### PR DESCRIPTION
## Summary
- simplify server connection check output so that only the HTTP status code is shown

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project Brewpad.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404b7384d0832a80ec19d4c9fdbc02