### PR TITLE
Show server recipes in debug settings

### DIFF
--- a/Brewpad/Models/RecipeStore.swift
+++ b/Brewpad/Models/RecipeStore.swift
@@ -7,6 +7,7 @@ class RecipeStore: ObservableObject {
     @Published private(set) var isInitialized = false
     @Published var showServerError = false
     @Published var serverResponse: String?
+    @Published var serverFetchedRecipes: [String] = []
     private let recipesDirectoryName = "Recipes"
     private let serverBaseURL = "https://bprs.mirreravencd.com/recipes/"
     private var hasLoadedRecipes = false
@@ -67,6 +68,10 @@ class RecipeStore: ObservableObject {
             }
 
             let fileNames = self.extractJSONFileNames(from: content)
+
+            DispatchQueue.main.async {
+                self.serverFetchedRecipes = fileNames
+            }
 
             let dispatchGroup = DispatchGroup()
 

--- a/Brewpad/Views/RecipeDebugView.swift
+++ b/Brewpad/Views/RecipeDebugView.swift
@@ -52,6 +52,18 @@ struct RecipeDebugView: View {
                             .font(.caption)
                             .foregroundColor(.gray)
                     }
+
+                    if !recipeStore.serverFetchedRecipes.isEmpty {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Fetched Recipes:")
+                                .font(.subheadline)
+                            ForEach(recipeStore.serverFetchedRecipes, id: \.self) { recipe in
+                                Text(recipe)
+                                    .font(.caption2)
+                                    .foregroundColor(.gray)
+                            }
+                        }
+                    }
                 }
             }
             .navigationTitle("Recipe Debug Info")

--- a/Brewpad/Views/SettingsView.swift
+++ b/Brewpad/Views/SettingsView.swift
@@ -306,6 +306,18 @@ struct SettingsView: View {
                                         .foregroundColor(.gray)
                                 }
 
+                                if !recipeStore.serverFetchedRecipes.isEmpty {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text("Fetched Recipes:")
+                                            .font(.subheadline)
+                                        ForEach(recipeStore.serverFetchedRecipes, id: \.self) { recipe in
+                                            Text(recipe)
+                                                .font(.caption2)
+                                                .foregroundColor(.gray)
+                                        }
+                                    }
+                                }
+
                                 Button(action: { recipeStore.checkServerConnection() }) {
                                     HStack {
                                         Image(systemName: "arrow.clockwise.circle.fill")


### PR DESCRIPTION
## Summary
- track list of recipes fetched from the server in `RecipeStore`
- display fetched recipe names in the Settings debug section
- also display fetched recipe names in `RecipeDebugView`

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68407856b9dc832a927e6b7596116658