### PR TITLE
Fix string literal in RecipeStore

### DIFF
--- a/Brewpad/Models/RecipeStore.swift
+++ b/Brewpad/Models/RecipeStore.swift
@@ -64,7 +64,7 @@ class RecipeStore: ObservableObject {
         URLSession.shared.dataTask(with: listingURL) { data, response, error in
             guard let data = data, error == nil,
                   let content = String(data: data, encoding: .utf8) else {
-                print("❌ Failed to fetch recipe listing: \(error?.localizedDescription ?? \"Unknown error\")")
+                print("❌ Failed to fetch recipe listing: \(error?.localizedDescription ?? "Unknown error")")
                 DispatchQueue.main.async {
                     self.hasFetchedServerRecipes = true
                     self.checkInitialization()


### PR DESCRIPTION
## Summary
- fix typo in RecipeStore error log string

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swiftc Brewpad/Models/RecipeStore.swift -o /tmp/RecipeStoreTest` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68407ce8ab44832a9cad0731f1b6b66f