### PR TITLE
Fix measurement conversion replacements

### DIFF
--- a/Brewpad/Utils/MeasurementConverter.swift
+++ b/Brewpad/Utils/MeasurementConverter.swift
@@ -36,11 +36,11 @@ struct MeasurementConverter {
                 // Find all matches and process them in reverse order
                 let matches = regex?.matches(in: text, options: [], range: nsRange) ?? []
                 for match in matches.reversed() {
-                    if let range = Range(match.range(at: 1), in: text),
-                       let value = Double(text[range]) {
+                    if let fullRange = Range(match.range, in: result),
+                       let valueRange = Range(match.range(at: 1), in: result),
+                       let value = Double(result[valueRange]) {
                         let convertedValue = converter(value)
-                        // Use the original unit to replace the correct measurement
-                        result = result.replacingOccurrences(of: text[range] + unit, with: convertedValue)
+                        result.replaceSubrange(fullRange, with: convertedValue)
                     }
                 }
             }

--- a/BrewpadTests/MeasurementConverterTests.swift
+++ b/BrewpadTests/MeasurementConverterTests.swift
@@ -25,4 +25,10 @@ struct MeasurementConverterTests {
         let result = MeasurementConverter.convert("20cm", toImperial: true)
         #expect(result.contains("7.9 inches"))
     }
+
+    @Test
+    func testMultipleOccurrences() async throws {
+        let result = MeasurementConverter.convert("Add 20g sugar and 20g flour", toImperial: true)
+        #expect(result.contains("Add 0.7 oz sugar and 0.7 oz flour"))
+    }
 }


### PR DESCRIPTION
## Summary
- replace matched ranges using `replaceSubrange` to avoid incorrect replacements
- test converting multiple measurements in one string

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68407ed36940832a9c1582374ab9386b