### PR TITLE
Fix downloader URL for remote recipes

### DIFF
--- a/Brewpad/Models/RecipeStore.swift
+++ b/Brewpad/Models/RecipeStore.swift
@@ -116,9 +116,16 @@ class RecipeStore: ObservableObject {
     }
     /// Downloads a single recipe file from the server and stores it locally.
     /// Any existing file with the same name will be overwritten.
+    /// The file is fetched from `https://bprs.mirreravencd.com/recipes/` using
+    /// the provided name with the `.brewpadrecipe` extension.
     private func downloadRecipe(named fileName: String, completion: @escaping () -> Void) {
-        guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first,
-              let downloadURL = URL(string: "\(serverBaseURL)/\(fileName)") else {
+        guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            completion()
+            return
+        }
+
+        let recipeName = fileName.hasSuffix(".brewpadrecipe") ? fileName : "\(fileName).brewpadrecipe"
+        guard let downloadURL = URL(string: "\(serverBaseURL)\(recipeName)") else {
             completion()
             return
         }
@@ -129,7 +136,7 @@ class RecipeStore: ObservableObject {
             try? FileManager.default.createDirectory(at: recipesDirectory, withIntermediateDirectories: true)
         }
 
-        let destinationURL = recipesDirectory.appendingPathComponent(fileName)
+        let destinationURL = recipesDirectory.appendingPathComponent(recipeName)
 
         URLSession.shared.dataTask(with: downloadURL) { data, _, error in
             guard let data = data, error == nil else {


### PR DESCRIPTION
## Summary
- ensure recipe downloader always downloads `<name>.brewpadrecipe`
- store the recipe with the final filename
- document download behavior

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68408182a488832a824eca9926375f6e