### PR TITLE
Fix unterminated string literals in RecipeStore

### DIFF
--- a/Brewpad/Models/RecipeStore.swift
+++ b/Brewpad/Models/RecipeStore.swift
@@ -66,7 +66,7 @@ class RecipeStore: ObservableObject {
         URLSession.shared.dataTask(with: listingURL) { data, response, error in
             guard let data = data, error == nil,
                   let content = String(data: data, encoding: .utf8) else {
-                print("❌ Failed to fetch recipe listing: \(error?.localizedDescription ?? \"Unknown error\")")
+                print("❌ Failed to fetch recipe listing: \(error?.localizedDescription ?? "Unknown error")")
                 DispatchQueue.main.async {
                     self.hasFetchedServerRecipes = true
                     self.checkInitialization()
@@ -157,7 +157,7 @@ class RecipeStore: ObservableObject {
 
         URLSession.shared.dataTask(with: downloadURL) { data, _, error in
             guard let data = data, error == nil else {
-                print("❌ Failed to download recipe \(fileName): \(error?.localizedDescription ?? \"Unknown error\")")
+                print("❌ Failed to download recipe \(fileName): \(error?.localizedDescription ?? "Unknown error")")
                 completion()
                 return
             }


### PR DESCRIPTION
## Summary
- fix syntax errors in RecipeStore

## Testing
- `swiftc Brewpad/Models/RecipeStore.swift -o /tmp/RecipeStore` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6840854315a0832a8b04e6fbffec9417