### PR TITLE
Fix recipe import recognition

### DIFF
--- a/Brewpad/Models/Recipe.swift
+++ b/Brewpad/Models/Recipe.swift
@@ -59,7 +59,7 @@ struct Recipe: Identifiable, Codable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        id = try container.decode(UUID.self, forKey: .id)
+        id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
         name = try container.decode(String.self, forKey: .name)
         category = try container.decode(Category.self, forKey: .category)
         description = try container.decode(String.self, forKey: .description)

--- a/Brewpad/Models/RecipeStore.swift
+++ b/Brewpad/Models/RecipeStore.swift
@@ -138,7 +138,9 @@ class RecipeStore: ObservableObject {
             return
         }
 
-        let recipeName = fileName.hasSuffix(".brewpadrecipe") ? fileName : "\(fileName).brewpadrecipe"
+        let recipeName = fileName.lowercased().hasSuffix(".brewpadrecipe")
+            ? fileName
+            : "\(fileName).brewpadrecipe"
         guard let downloadURL = URL(string: "\(serverBaseURL)\(recipeName)") else {
             print("❌ Invalid download URL for \(fileName)")
             completion()
@@ -254,7 +256,8 @@ class RecipeStore: ObservableObject {
             at: recipesDirectory,
             includingPropertiesForKeys: nil
         ).filter({
-            $0.pathExtension == "json" || $0.pathExtension == "brewpadrecipe"
+            let ext = $0.pathExtension.lowercased()
+            return ext == "json" || ext == "brewpadrecipe"
         }) else {
             return
         }


### PR DESCRIPTION
## Summary
- relax `Recipe` decoding to create an id if the JSON file doesn't include one
- handle `.brewpadrecipe` file extension case‑insensitively in download
- recognise recipe files with uppercased extensions

## Testing
- `swiftc -parse Brewpad/Models/Recipe.swift Brewpad/Models/RecipeStore.swift`

------
https://chatgpt.com/codex/tasks/task_e_6840862a28ec832a92edc6f6789dcc81