### PR TITLE
Enable Files app integration

### DIFF
--- a/Brewpad/Info.plist
+++ b/Brewpad/Info.plist
@@ -29,7 +29,7 @@
                 <string>com.mirreraven.brewpad.recipe</string>
             </array>
             <key>LSSupportsOpeningDocumentsInPlace</key>
-            <false/>
+            <true/>
             <key>LSHandlerContentTag</key>
             <string>brewpadrecipe</string>
         </dict>
@@ -96,7 +96,9 @@
         </dict>
     </array>
     <key>LSSupportsOpeningDocumentsInPlace</key>
-    <false/>
+    <true/>
+    <key>UIFileSharingEnabled</key>
+    <true/>
     <key>CFBundleAllowMixedLocalizations</key>
     <true/>
     <key>CFBundleDevelopmentRegion</key>

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ The app is built with **offline-first principles**, with optional support for se
   - **Smart sections** like “Trending Coffee”, “Quick & Easy”, or “Chocolate Comforts”
   - A fun **“Surprise Me” button** to randomly select a recipe from your collection
 
+### 📁 Files App Integration
+- Access saved recipes directly via the iOS Files app.
+
 ### 📖 Recipe Details
 Each recipe contains:
 - Title and category


### PR DESCRIPTION
## Summary
- allow Brewpad recipes to show up in the Files app
- document Files app integration in README

## Testing
- `xcodebuild -list -project Brewpad.xcodeproj` *(fails: command not found)*
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684087f3eb70832aa78476b2b3194637