### PR TITLE
Simplify SplashScreen shake animation

### DIFF
--- a/Brewpad/Views/SplashScreen.swift
+++ b/Brewpad/Views/SplashScreen.swift
@@ -71,30 +71,9 @@ struct SplashScreen: View {
     }
     
     private func startShakeAnimation() {
-        withAnimation(.easeInOut(duration: 0.1)) {
-            rotationAngle = -10
-        }
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            withAnimation(.easeInOut(duration: 0.1)) {
-                rotationAngle = 10
-            }
-            
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                withAnimation(.easeInOut(duration: 0.1)) {
-                    rotationAngle = -10
-                }
-                
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                    withAnimation(.easeInOut(duration: 0.1)) {
-                        rotationAngle = 0
-                    }
-                    
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-                        startShakeAnimation()
-                    }
-                }
-            }
+        rotationAngle = -10
+        withAnimation(.easeInOut(duration: 0.1).repeatForever(autoreverses: true)) {
+            rotationAngle = 10
         }
     }
     


### PR DESCRIPTION
## Summary
- replace nested `DispatchQueue.asyncAfter` calls with a single repeating animation

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840c0264754832ab2c82a2104a885d9