### PR TITLE
Optimize regex usage in MeasurementConverter

### DIFF
--- a/Brewpad/Utils/MeasurementConverter.swift
+++ b/Brewpad/Utils/MeasurementConverter.swift
@@ -1,40 +1,68 @@
 import Foundation
 
 struct MeasurementConverter {
-    static func convert(_ text: String, toImperial: Bool) -> String {
-        // Match patterns like "22.5g", "120ml", "93°C", "1cm"
-        let patterns: [(String, String, (Double) -> String)] = [
-            // Weight: grams
-            ("([0-9]+\\.?[0-9]*)g\\b", "g", { value in
+    private static let weightRegex = try! NSRegularExpression(
+        pattern: "([0-9]+\\.?[0-9]*)g\\b",
+        options: []
+    )
+    private static let volumeRegex = try! NSRegularExpression(
+        pattern: "([0-9]+\\.?[0-9]*)ml\\b",
+        options: []
+    )
+    private static let temperatureRegex = try! NSRegularExpression(
+        pattern: "([0-9]+\\.?[0-9]*)°C\\b",
+        options: []
+    )
+    private static let lengthRegex = try! NSRegularExpression(
+        pattern: "([0-9]+\\.?[0-9]*)cm\\b",
+        options: []
+    )
+
+    private static let patterns: [(NSRegularExpression, (Double) -> String)] = [
+        // Weight: grams
+        (
+            weightRegex,
+            { value in
                 let oz = value * 0.035274
                 return String(format: "%.1f oz", oz)
-            }),
-            // Volume: milliliters
-            ("([0-9]+\\.?[0-9]*)ml\\b", "ml", { value in
+            }
+        ),
+        // Volume: milliliters
+        (
+            volumeRegex,
+            { value in
                 let flOz = value * 0.033814
                 return String(format: "%.1f fl oz", flOz)
-            }),
-            // Temperature: Celsius
-            ("([0-9]+\\.?[0-9]*)°C\\b", "°C", { value in
+            }
+        ),
+        // Temperature: Celsius
+        (
+            temperatureRegex,
+            { value in
                 let fahrenheit = (value * 9/5) + 32
                 return String(format: "%.0f°F", fahrenheit)
-            }),
-            // Length: centimeters
-            ("([0-9]+\\.?[0-9]*)cm\\b", "cm", { value in
+            }
+        ),
+        // Length: centimeters
+        (
+            lengthRegex,
+            { value in
                 let inches = value * 0.393701
                 return String(format: "%.1f inches", inches)
-            })
-        ]
+            }
+        )
+    ]
+
+    static func convert(_ text: String, toImperial: Bool) -> String {
         
         var result = text
         
         if toImperial {
-            for (pattern, unit, converter) in patterns {
-                let regex = try? NSRegularExpression(pattern: pattern, options: [])
+            for (regex, converter) in patterns {
                 let nsRange = NSRange(text.startIndex..<text.endIndex, in: text)
-                
+
                 // Find all matches and process them in reverse order
-                let matches = regex?.matches(in: text, options: [], range: nsRange) ?? []
+                let matches = regex.matches(in: text, options: [], range: nsRange)
                 for match in matches.reversed() {
                     if let fullRange = Range(match.range, in: result),
                        let valueRange = Range(match.range(at: 1), in: result),


### PR DESCRIPTION
## Summary
- reuse compiled `NSRegularExpression` objects in `MeasurementConverter`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840c02491e4832a934e1a162390b9ac