### PR TITLE
Update age verification to birthday input

### DIFF
--- a/Brewpad/Views/OnboardingView.swift
+++ b/Brewpad/Views/OnboardingView.swift
@@ -141,20 +141,23 @@ struct UserSetupView: View {
                             .foregroundColor(.gray)
                     }
                     
-                    // Age Verification
+                    // Birth Date
                     VStack(alignment: .leading, spacing: 8) {
-                        Text("Age Verification")
+                        Text("Birthday")
                             .font(.headline)
-                        
-                        Toggle(isOn: $settingsManager.isOver18) {
-                            HStack {
-                                Image(systemName: "person.crop.circle.badge.checkmark")
-                                    .foregroundColor(.blue)
-                                Text("I am 18 or older")
-                            }
-                        }
-                        .toggleStyle(SwitchToggleStyle(tint: .blue))
-                        
+
+                        DatePicker(
+                            "Select your birth date",
+                            selection: Binding<Date>(
+                                get: {
+                                    settingsManager.birthdate ?? Calendar.current.date(byAdding: .year, value: -18, to: Date())!
+                                },
+                                set: { settingsManager.birthdate = $0 }
+                            ),
+                            displayedComponents: .date
+                        )
+                        .datePickerStyle(.compact)
+
                         Text("Required for accessing alcoholic beverage recipes. You can change this later in settings.")
                             .font(.caption)
                             .foregroundColor(.gray)

--- a/Brewpad/Views/SettingsView.swift
+++ b/Brewpad/Views/SettingsView.swift
@@ -88,20 +88,23 @@ struct SettingsView: View {
                     
                     Divider()
                     
-                    // Age Verification
+                    // Birth Date
                     VStack(alignment: .leading, spacing: 8) {
-                        Text("Age Verification")
+                        Text("Birthday")
                             .font(.headline)
-                        
-                        Toggle(isOn: $settingsManager.isOver18) {
-                            HStack {
-                                Image(systemName: "person.crop.circle.badge.checkmark")
-                                    .foregroundColor(.blue)
-                                Text("I am 18 or older")
-                            }
-                        }
-                        .toggleStyle(SwitchToggleStyle(tint: .blue))
-                        
+
+                        DatePicker(
+                            "Select your birth date",
+                            selection: Binding<Date>(
+                                get: {
+                                    settingsManager.birthdate ?? Calendar.current.date(byAdding: .year, value: -18, to: Date())!
+                                },
+                                set: { settingsManager.birthdate = $0 }
+                            ),
+                            displayedComponents: .date
+                        )
+                        .datePickerStyle(.compact)
+
                         Text("Required for accessing alcoholic beverage recipes")
                             .font(.caption)
                             .foregroundColor(.gray)
@@ -253,7 +256,7 @@ struct SettingsView: View {
                                         // Reset all onboarding-related settings
                                         settingsManager.hasCompletedOnboarding = false
                                         settingsManager.username = nil
-                                        settingsManager.isOver18 = false
+                                        settingsManager.birthdate = nil
                                         settingsManager.isReplayingTutorial = false // Ensure full onboarding
                                     }
                                 }) {
@@ -381,7 +384,7 @@ struct SettingsView: View {
                     // Reset all onboarding-related settings
                     settingsManager.hasCompletedOnboarding = false
                     settingsManager.username = nil
-                    settingsManager.isOver18 = false
+                    settingsManager.birthdate = nil
                     settingsManager.isReplayingTutorial = false // Ensure full onboarding
                 }
             }

--- a/Brewpad/Views/WelcomeScreen.swift
+++ b/Brewpad/Views/WelcomeScreen.swift
@@ -37,17 +37,20 @@ struct WelcomeScreen: View {
                                     .autocapitalization(.words)
                             }
                             
-                            // Age Verification
+                            // Birth Date
                             VStack(alignment: .leading, spacing: 8) {
-                                Toggle(isOn: $settingsManager.isOver18) {
-                                    HStack {
-                                        Image(systemName: "person.crop.circle.badge.checkmark")
-                                            .foregroundColor(.blue)
-                                        Text("I am 18 or older")
-                                    }
-                                }
-                                .toggleStyle(SwitchToggleStyle(tint: .blue))
-                                
+                                DatePicker(
+                                    "Birthday",
+                                    selection: Binding<Date>(
+                                        get: {
+                                            settingsManager.birthdate ?? Calendar.current.date(byAdding: .year, value: -18, to: Date())!
+                                        },
+                                        set: { settingsManager.birthdate = $0 }
+                                    ),
+                                    displayedComponents: .date
+                                )
+                                .datePickerStyle(.compact)
+
                                 Text("Required for accessing alcoholic beverage recipes")
                                     .font(.caption)
                                     .foregroundColor(.gray)


### PR DESCRIPTION
## Summary
- ask for birthday in onboarding, welcome screen and settings
- store birthdate in `SettingsManager` and compute `isOver18`
- clear stored birthdate when resetting onboarding

## Testing
- `swift --version`
- `swift test` *(fails: no Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840c1bf7f34832a806dd5829731afe1