### PR TITLE
Fix initialization in SettingsManager

### DIFF
--- a/Brewpad/Managers/SettingsManager.swift
+++ b/Brewpad/Managers/SettingsManager.swift
@@ -38,7 +38,7 @@ class SettingsManager: ObservableObject {
     @Published var birthdate: Date? {
         didSet {
             UserDefaults.standard.set(birthdate, forKey: "birthdate")
-            isOver18 = calculateIsOver18(from: birthdate)
+            isOver18 = Self.calculateIsOver18(from: birthdate)
         }
     }
 
@@ -89,7 +89,7 @@ class SettingsManager: ObservableObject {
 
         if let savedDate = UserDefaults.standard.object(forKey: "birthdate") as? Date {
             self.birthdate = savedDate
-            self.isOver18 = calculateIsOver18(from: savedDate)
+            self.isOver18 = Self.calculateIsOver18(from: savedDate)
         } else {
             self.birthdate = nil
             // Support older versions that stored the boolean directly
@@ -104,7 +104,7 @@ class SettingsManager: ObservableObject {
         }
     }
 
-    private func calculateIsOver18(from date: Date?) -> Bool {
+    private static func calculateIsOver18(from date: Date?) -> Bool {
         guard let date else { return false }
         if let years = Calendar.current.dateComponents([.year], from: date, to: Date()).year {
             return years >= 18


### PR DESCRIPTION
## Summary
- fix initializer usage of `calculateIsOver18` before all properties are set
- make `calculateIsOver18` static
- adjust calls in property observers and initializer

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840c2baa440832aa7fe094260957b27