### PR TITLE
Add birthday confetti on splash screen

### DIFF
--- a/Brewpad/Resources/quips.json
+++ b/Brewpad/Resources/quips.json
@@ -139,6 +139,13 @@
             "Easter celebration sips with {name} 🥚",
             "Hoppy brewing with {name} 🌷",
             "Easter Sunday perfection by {name} 🐣"
+        ],
+        "birthday": [
+            "Happy Birthday, {name}! 🎉",
+            "Celebrating {name}'s special day with a perfect brew 🎂",
+            "Birthday cheers and coffee for {name}! ☕️",
+            "Another year, another great cup for {name} 🎈",
+            "Warm wishes and hot coffee for {name}'s birthday 🎁"
         ]
     }
-} 
+}

--- a/Brewpad/Utilities/TimeGreeting.swift
+++ b/Brewpad/Utilities/TimeGreeting.swift
@@ -22,6 +22,7 @@ struct TimeGreeting {
         let halloween: [String]
         let thanksgiving: [String]
         let easter: [String]
+        let birthday: [String]
     }
     
     private static var quips: QuipsData? = {
@@ -72,7 +73,18 @@ struct TimeGreeting {
             
             return quip.replacingOccurrences(of: "{name}", with: name)
         }
-        
+
+        // Birthday check
+        if let birthday = settingsManager.birthdate {
+            let calendar = Calendar.current
+            let today = calendar.dateComponents([.month, .day], from: Date())
+            let birthComponents = calendar.dateComponents([.month, .day], from: birthday)
+            if today.month == birthComponents.month && today.day == birthComponents.day,
+               let quip = quips?.seasonal.birthday.randomElement() {
+                return quip.replacingOccurrences(of: "{name}", with: name)
+            }
+        }
+
         return checkActualSeasonalQuip(name: name)
     }
     

--- a/Brewpad/Views/ConfettiView.swift
+++ b/Brewpad/Views/ConfettiView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+import UIKit
+
+struct ConfettiView: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView(frame: .zero)
+        let emitter = CAEmitterLayer()
+        emitter.emitterPosition = CGPoint(x: UIScreen.main.bounds.width / 2, y: -10)
+        emitter.emitterShape = .line
+        emitter.emitterSize = CGSize(width: UIScreen.main.bounds.width, height: 2)
+
+        let colors: [UIColor] = [.systemRed, .systemBlue, .systemYellow, .systemGreen, .systemOrange, .systemPurple]
+        emitter.emitterCells = colors.map { color in
+            let cell = CAEmitterCell()
+            cell.birthRate = 6
+            cell.lifetime = 4.0
+            cell.velocity = 200
+            cell.velocityRange = 50
+            cell.emissionLongitude = .pi
+            cell.spin = 4
+            cell.spinRange = 8
+            cell.scale = 0.6
+            cell.scaleRange = 0.3
+            cell.color = color.cgColor
+            cell.contents = UIImage(systemName: "circle.fill")?.cgImage
+            return cell
+        }
+
+        view.layer.addSublayer(emitter)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            emitter.birthRate = 0
+        }
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {}
+}

--- a/Brewpad/Views/SplashScreen.swift
+++ b/Brewpad/Views/SplashScreen.swift
@@ -5,6 +5,13 @@ struct SplashScreen: View {
     @State private var rotationAngle: Double = 0
     @State private var quipOpacity: Double = 0
     @State private var currentQuip: String = ""
+    private var isBirthday: Bool {
+        guard let birthday = settingsManager.birthdate else { return false }
+        let calendar = Calendar.current
+        let today = calendar.dateComponents([.month, .day], from: Date())
+        let components = calendar.dateComponents([.month, .day], from: birthday)
+        return today.month == components.month && today.day == components.day
+    }
     let action: AppState.AppAction?
     
     init(action: AppState.AppAction? = nil) {
@@ -39,32 +46,39 @@ struct SplashScreen: View {
     }
     
     var body: some View {
-        VStack(spacing: 30) {
-            Image(systemName: "mug.fill")
-                .font(.system(size: 80))
-                .foregroundColor(cupColor)
-                .rotationEffect(.degrees(rotationAngle))
-                .onAppear {
-                    startShakeAnimation()
-                }
-            
-            Text("Brewpad")
-                .font(.largeTitle)
-                .bold()
-            
-            // Quip Text
-            Text(action?.quip ?? currentQuip)
-                .font(.subheadline)
-                .foregroundColor(.gray)
-                .multilineTextAlignment(.center)
-                .opacity(quipOpacity)
-                .animation(.easeIn(duration: 0.5).delay(0.5), value: quipOpacity)
-                .onAppear {
-                    quipOpacity = 1
-                    if action == nil {
-                        currentQuip = TimeGreeting.getQuip(username: settingsManager.username, settingsManager: settingsManager)
+        ZStack {
+            VStack(spacing: 30) {
+                Image(systemName: "mug.fill")
+                    .font(.system(size: 80))
+                    .foregroundColor(cupColor)
+                    .rotationEffect(.degrees(rotationAngle))
+                    .onAppear {
+                        startShakeAnimation()
                     }
-                }
+
+                Text("Brewpad")
+                    .font(.largeTitle)
+                    .bold()
+
+                // Quip Text
+                Text(action?.quip ?? currentQuip)
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
+                    .multilineTextAlignment(.center)
+                    .opacity(quipOpacity)
+                    .animation(.easeIn(duration: 0.5).delay(0.5), value: quipOpacity)
+                    .onAppear {
+                        quipOpacity = 1
+                        if action == nil {
+                            currentQuip = TimeGreeting.getQuip(username: settingsManager.username, settingsManager: settingsManager)
+                        }
+                    }
+            }
+
+            if isBirthday {
+                ConfettiView()
+                    .ignoresSafeArea()
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color(uiColor: .systemBackground))

--- a/BrewpadTests/TimeGreetingTests.swift
+++ b/BrewpadTests/TimeGreetingTests.swift
@@ -24,4 +24,12 @@ struct TimeGreetingTests {
         let quip = TimeGreeting.getQuip(username: "Alice", settingsManager: settings)
         #expect(!quip.isEmpty)
     }
+
+    @Test
+    func testBirthdayQuip() async throws {
+        let settings = SettingsManager()
+        settings.birthdate = Date()
+        let quip = TimeGreeting.getQuip(username: "Alice", settingsManager: settings)
+        #expect(quip.contains("Alice"))
+    }
 }

--- a/BrewpadTests/quips.json
+++ b/BrewpadTests/quips.json
@@ -139,6 +139,13 @@
             "Easter celebration sips with {name} 🥚",
             "Hoppy brewing with {name} 🌷",
             "Easter Sunday perfection by {name} 🐣"
+        ],
+        "birthday": [
+            "Happy Birthday, {name}! 🎉",
+            "Celebrating {name}'s special day with a perfect brew 🎂",
+            "Birthday cheers and coffee for {name}! ☕️",
+            "Another year, another great cup for {name} 🎈",
+            "Warm wishes and hot coffee for {name}'s birthday 🎁"
         ]
     }
-} 
+}


### PR DESCRIPTION
## Summary
- support birthday quips in `TimeGreeting`
- add confetti animation overlay for birthdays
- include birthday messages in `quips.json`
- test birthday quip logic

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840c390fdf0832a953a91f94879c8b9