### PR TITLE
Update confetti visuals

### DIFF
--- a/Brewpad/Views/ConfettiView.swift
+++ b/Brewpad/Views/ConfettiView.swift
@@ -9,29 +9,41 @@ struct ConfettiView: UIViewRepresentable {
         emitter.emitterShape = .line
         emitter.emitterSize = CGSize(width: UIScreen.main.bounds.width, height: 2)
 
-        let colors: [UIColor] = [.systemRed, .systemBlue, .systemYellow, .systemGreen, .systemOrange, .systemPurple]
+        let colors: [UIColor] = [
+            .systemRed, .systemBlue, .systemYellow, .systemGreen,
+            .systemOrange, .systemPurple, .systemPink, .systemTeal
+        ]
+        let rectangle = Self.makeRectangleImage(size: CGSize(width: 8, height: 4))?.cgImage
         emitter.emitterCells = colors.map { color in
             let cell = CAEmitterCell()
-            cell.birthRate = 6
+            cell.birthRate = 2
             cell.lifetime = 4.0
             cell.velocity = 200
             cell.velocityRange = 50
             cell.emissionLongitude = .pi
             cell.spin = 4
             cell.spinRange = 8
-            cell.scale = 0.6
-            cell.scaleRange = 0.3
+            cell.scale = 0.5
+            cell.scaleRange = 0.2
             cell.color = color.cgColor
-            cell.contents = UIImage(systemName: "circle.fill")?.cgImage
+            cell.contents = rectangle
             return cell
         }
 
         view.layer.addSublayer(emitter)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             emitter.birthRate = 0
         }
         return view
     }
 
     func updateUIView(_ uiView: UIView, context: Context) {}
+
+    private static func makeRectangleImage(size: CGSize) -> UIImage? {
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { ctx in
+            UIColor.white.setFill()
+            ctx.fill(CGRect(origin: .zero, size: size))
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- tweak confetti style
- confetti now shows colorful rectangular pieces
- animation runs once from top to bottom

## Testing
- `swift -version`
- `xcodebuild -list -project Brewpad.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c4fe404c832a9468c3c354dd51ea