### PR TITLE
Trigger confetti after cup loads

### DIFF
--- a/Brewpad/Views/ConfettiView.swift
+++ b/Brewpad/Views/ConfettiView.swift
@@ -16,11 +16,12 @@ struct ConfettiView: UIViewRepresentable {
         let rectangle = Self.makeRectangleImage(size: CGSize(width: 8, height: 4))?.cgImage
         emitter.emitterCells = colors.map { color in
             let cell = CAEmitterCell()
-            cell.birthRate = 2
-            cell.lifetime = 4.0
-            cell.velocity = 200
-            cell.velocityRange = 50
+            cell.birthRate = 8
+            cell.lifetime = 5.0
+            cell.velocity = 600
+            cell.velocityRange = 200
             cell.emissionLongitude = .pi
+            cell.yAcceleration = -150
             cell.spin = 4
             cell.spinRange = 8
             cell.scale = 0.5

--- a/Brewpad/Views/SplashScreen.swift
+++ b/Brewpad/Views/SplashScreen.swift
@@ -5,6 +5,7 @@ struct SplashScreen: View {
     @State private var rotationAngle: Double = 0
     @State private var quipOpacity: Double = 0
     @State private var currentQuip: String = ""
+    @State private var showConfetti: Bool = false
     private var isBirthday: Bool {
         guard let birthday = settingsManager.birthdate else { return false }
         let calendar = Calendar.current
@@ -54,6 +55,9 @@ struct SplashScreen: View {
                     .rotationEffect(.degrees(rotationAngle))
                     .onAppear {
                         startShakeAnimation()
+                        if isBirthday {
+                            showConfetti = true
+                        }
                     }
 
                 Text("Brewpad")
@@ -75,7 +79,7 @@ struct SplashScreen: View {
                     }
             }
 
-            if isBirthday {
+            if isBirthday && showConfetti {
                 ConfettiView()
                     .ignoresSafeArea()
             }


### PR DESCRIPTION
## Summary
- update ConfettiView for stronger, decelerating burst
- start the confetti once the cup image appears

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840c62b999c832a9001568c3cdba490