### PR TITLE
Add birthday confetti timing tweaks

### DIFF
--- a/Brewpad/Models/RecipeStore.swift
+++ b/Brewpad/Models/RecipeStore.swift
@@ -13,15 +13,27 @@ class RecipeStore: ObservableObject {
     private var hasLoadedRecipes = false
     private var hasFetchedServerRecipes = false
     private var minimumSplashTimeElapsed = false
+    private var minimumSplashDuration: TimeInterval = 2
     
     init() {
+        // Determine if today is the user's birthday. If so, extend the
+        // minimum splash screen duration to three seconds instead of two.
+        if let birthday = UserDefaults.standard.object(forKey: "birthdate") as? Date {
+            let calendar = Calendar.current
+            let today = calendar.dateComponents([.month, .day], from: Date())
+            let components = calendar.dateComponents([.month, .day], from: birthday)
+            if today.month == components.month && today.day == components.day {
+                minimumSplashDuration = 3
+            }
+        }
+
         // Start loading immediately
         loadRecipes()
         fetchServerRecipes()
         checkServerConnection()
-        
+
         // Ensure minimum splash screen duration
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + minimumSplashDuration) {
             self.minimumSplashTimeElapsed = true
             self.checkInitialization()
         }

--- a/Brewpad/Views/ConfettiView.swift
+++ b/Brewpad/Views/ConfettiView.swift
@@ -17,11 +17,11 @@ struct ConfettiView: UIViewRepresentable {
         emitter.emitterCells = colors.map { color in
             let cell = CAEmitterCell()
             cell.birthRate = 8
-            cell.lifetime = 5.0
-            cell.velocity = 600
-            cell.velocityRange = 200
-            cell.emissionLongitude = .pi
-            cell.yAcceleration = -150
+            cell.lifetime = 6.0
+            cell.velocity = 200
+            cell.velocityRange = 100
+            cell.emissionLongitude = .pi / 2
+            cell.yAcceleration = 300
             cell.spin = 4
             cell.spinRange = 8
             cell.scale = 0.5

--- a/Brewpad/Views/SplashScreen.swift
+++ b/Brewpad/Views/SplashScreen.swift
@@ -55,9 +55,6 @@ struct SplashScreen: View {
                     .rotationEffect(.degrees(rotationAngle))
                     .onAppear {
                         startShakeAnimation()
-                        if isBirthday {
-                            showConfetti = true
-                        }
                     }
 
                 Text("Brewpad")
@@ -75,6 +72,9 @@ struct SplashScreen: View {
                         quipOpacity = 1
                         if action == nil {
                             currentQuip = TimeGreeting.getQuip(username: settingsManager.username, settingsManager: settingsManager)
+                        }
+                        if isBirthday {
+                            showConfetti = true
                         }
                     }
             }


### PR DESCRIPTION
## Summary
- adjust confetti animation so particles fall downward and off screen
- trigger birthday confetti when the quip text appears
- extend minimum splash screen duration to three seconds on birthdays

## Testing
- `swift test --enable-test-discovery` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840c741c41c832ab4767844b2d5d0a5