### PR TITLE
Delay birthday confetti until quip reveal

### DIFF
--- a/Brewpad/Views/ConfettiView.swift
+++ b/Brewpad/Views/ConfettiView.swift
@@ -6,8 +6,8 @@ struct ConfettiView: UIViewRepresentable {
         let view = UIView(frame: .zero)
         let emitter = CAEmitterLayer()
         emitter.emitterPosition = CGPoint(x: UIScreen.main.bounds.width / 2, y: -10)
-        emitter.emitterShape = .line
-        emitter.emitterSize = CGSize(width: UIScreen.main.bounds.width, height: 2)
+        emitter.emitterShape = .point
+        emitter.emitterSize = CGSize(width: 1, height: 1)
 
         let colors: [UIColor] = [
             .systemRed, .systemBlue, .systemYellow, .systemGreen,
@@ -21,6 +21,7 @@ struct ConfettiView: UIViewRepresentable {
             cell.velocity = 200
             cell.velocityRange = 100
             cell.emissionLongitude = .pi / 2
+            cell.emissionRange = .pi / 4
             cell.yAcceleration = 300
             cell.spin = 4
             cell.spinRange = 8

--- a/Brewpad/Views/SplashScreen.swift
+++ b/Brewpad/Views/SplashScreen.swift
@@ -74,7 +74,9 @@ struct SplashScreen: View {
                             currentQuip = TimeGreeting.getQuip(username: settingsManager.username, settingsManager: settingsManager)
                         }
                         if isBirthday {
-                            showConfetti = true
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                                showConfetti = true
+                            }
                         }
                     }
             }


### PR DESCRIPTION
## Summary
- confetti emitter now spawns from a single point at the top center and sprays downward
- birthday confetti now waits for the quip to appear before triggering

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840c84ad200832a917ef470204b84b4