### PR TITLE
Update confetti

### DIFF
--- a/Brewpad/Views/ConfettiView.swift
+++ b/Brewpad/Views/ConfettiView.swift
@@ -5,9 +5,11 @@ struct ConfettiView: UIViewRepresentable {
     func makeUIView(context: Context) -> UIView {
         let view = UIView(frame: .zero)
         let emitter = CAEmitterLayer()
+        // Emit from the full width of the screen so the celebration feels
+        // like it originates across the entire top edge.
         emitter.emitterPosition = CGPoint(x: UIScreen.main.bounds.width / 2, y: -10)
-        emitter.emitterShape = .point
-        emitter.emitterSize = CGSize(width: 1, height: 1)
+        emitter.emitterShape = .line
+        emitter.emitterSize = CGSize(width: UIScreen.main.bounds.width, height: 1)
 
         let colors: [UIColor] = [
             .systemRed, .systemBlue, .systemYellow, .systemGreen,

--- a/Brewpad/Views/SplashScreen.swift
+++ b/Brewpad/Views/SplashScreen.swift
@@ -74,7 +74,8 @@ struct SplashScreen: View {
                             currentQuip = TimeGreeting.getQuip(username: settingsManager.username, settingsManager: settingsManager)
                         }
                         if isBirthday {
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                            // Reveal confetti as the quip appears.
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                                 showConfetti = true
                             }
                         }


### PR DESCRIPTION
## Summary
- confetti originates from the full screen width
- reveal the confetti right when the quip appears

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840c92e041c832abd0c0d708f3618ed