### PR TITLE
Handle nil date components safely

### DIFF
--- a/Brewpad/Utilities/TimeGreeting.swift
+++ b/Brewpad/Utilities/TimeGreeting.swift
@@ -91,8 +91,9 @@ struct TimeGreeting {
     // Move the original seasonal check logic to a separate function
     private static func checkActualSeasonalQuip(name: String) -> String? {
         let today = Calendar.current.dateComponents([.month, .day], from: Date())
-        let month = today.month!
-        let day = today.day!
+        guard let month = today.month, let day = today.day else {
+            return nil
+        }
         
         let seasonalQuips: [String]? = {
             guard let seasonal = quips?.seasonal else { return nil }

--- a/Brewpad/Views/SplashScreen.swift
+++ b/Brewpad/Views/SplashScreen.swift
@@ -26,8 +26,9 @@ struct SplashScreen: View {
         
         // Check for actual holiday
         let today = Calendar.current.dateComponents([.month, .day], from: Date())
-        let month = today.month!
-        let day = today.day!
+        guard let month = today.month, let day = today.day else {
+            return HolidayTheme.getColor(for: nil)
+        }
         
         let holiday: SettingsManager.Holiday? = {
             switch (month, day) {


### PR DESCRIPTION
## Summary
- protect against missing month/day values when determining holiday color and seasonal quip

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840cae24d90832a9faec6562d4d092e