### PR TITLE
Fix regex operations on converted text

### DIFF
--- a/Brewpad/Utils/MeasurementConverter.swift
+++ b/Brewpad/Utils/MeasurementConverter.swift
@@ -56,13 +56,13 @@ struct MeasurementConverter {
     static func convert(_ text: String, toImperial: Bool) -> String {
         
         var result = text
-        
+
         if toImperial {
             for (regex, converter) in patterns {
-                let nsRange = NSRange(text.startIndex..<text.endIndex, in: text)
+                let nsRange = NSRange(result.startIndex..<result.endIndex, in: result)
 
                 // Find all matches and process them in reverse order
-                let matches = regex.matches(in: text, options: [], range: nsRange)
+                let matches = regex.matches(in: result, options: [], range: nsRange)
                 for match in matches.reversed() {
                     if let fullRange = Range(match.range, in: result),
                        let valueRange = Range(match.range(at: 1), in: result),

--- a/BrewpadTests/MeasurementConverterTests.swift
+++ b/BrewpadTests/MeasurementConverterTests.swift
@@ -31,4 +31,11 @@ struct MeasurementConverterTests {
         let result = MeasurementConverter.convert("Add 20g sugar and 20g flour", toImperial: true)
         #expect(result.contains("Add 0.7 oz sugar and 0.7 oz flour"))
     }
+
+    @Test
+    func testMixedUnitsInSentence() async throws {
+        let result = MeasurementConverter.convert("Heat 200ml water to 93°C", toImperial: true)
+        #expect(result.contains("6.8 fl oz"))
+        #expect(result.contains("199°F"))
+    }
 }


### PR DESCRIPTION
## Summary
- convert regex matches on the latest result string
- add a test for mixed units in one sentence

## Testing
- `swift test --list-tests` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840cae3ba10832a9673dc54442b34f1