### PR TITLE
Add Brewpad Dark theme

### DIFF
--- a/Brewpad/ContentView.swift
+++ b/Brewpad/ContentView.swift
@@ -64,10 +64,12 @@ struct ContentView: View {
                         RecipeEditorView(recipe: recipe, isImporting: true)
                     }
                 }
+                .tint(settingsManager.colors.accent)
             } else {
                 SplashScreen()
             }
         }
+        .background(settingsManager.colors.background)
         .animation(.easeInOut(duration: 0.3), value: recipeStore.isInitialized)
         .animation(.easeInOut(duration: 0.3), value: settingsManager.hasCompletedOnboarding)
         .alert("Server Not Reachable", isPresented: $recipeStore.showServerError) {

--- a/Brewpad/Managers/SettingsManager.swift
+++ b/Brewpad/Managers/SettingsManager.swift
@@ -60,12 +60,13 @@ class SettingsManager: ObservableObject {
         case system = "System"
         case light = "Light"
         case dark = "Dark"
+        case brewpadDark = "Brewpad Dark"
         
         var colorScheme: ColorScheme? {
             switch self {
             case .system: return nil
             case .light: return .light
-            case .dark: return .dark
+            case .dark, .brewpadDark: return .dark
             }
         }
     }
@@ -73,6 +74,15 @@ class SettingsManager: ObservableObject {
     @Published var theme: Theme = .system {
         didSet {
             UserDefaults.standard.set(theme.rawValue, forKey: "theme")
+        }
+    }
+
+    var colors: ThemeColors {
+        switch theme {
+        case .system: return ThemeColors.system
+        case .light: return ThemeColors.light
+        case .dark: return ThemeColors.dark
+        case .brewpadDark: return ThemeColors.brewpadDark
         }
     }
     

--- a/Brewpad/Utilities/ThemeColors.swift
+++ b/Brewpad/Utilities/ThemeColors.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct ThemeColors {
+    let background: Color
+    let accent: Color
+    let textPrimary: Color
+    let textSecondary: Color
+    let buttonBackground: Color
+    let buttonText: Color
+    let divider: Color
+    let highlight: Color
+
+    static let system = ThemeColors(
+        background: Color(uiColor: .systemBackground),
+        accent: .blue,
+        textPrimary: Color.primary,
+        textSecondary: Color.secondary,
+        buttonBackground: .blue,
+        buttonText: .white,
+        divider: Color(UIColor.separator),
+        highlight: Color(UIColor.systemFill)
+    )
+
+    static let light = system
+    static let dark = system
+
+    static let brewpadDark = ThemeColors(
+        background: Color(hex: "#2B1A12"),
+        accent: Color(hex: "#F5E8DA"),
+        textPrimary: Color(hex: "#F5E8DA"),
+        textSecondary: Color(hex: "#B49E8A"),
+        buttonBackground: Color(hex: "#7A5C48"),
+        buttonText: Color(hex: "#FFF7F0"),
+        divider: Color(hex: "#3C2A1E"),
+        highlight: Color(hex: "#C7A98C")
+    )
+}
+
+extension Color {
+    init(hex: String) {
+        var hex = hex
+        if hex.hasPrefix("#") { hex.removeFirst() }
+        var int = UInt64()
+        Scanner(string: hex).scanHexInt64(&int)
+        let r, g, b: UInt64
+        switch hex.count {
+        case 6:
+            (r, g, b) = ((int >> 16) & 0xFF, (int >> 8) & 0xFF, int & 0xFF)
+        default:
+            (r, g, b) = (1,1,1)
+        }
+        self.init(red: Double(r)/255, green: Double(g)/255, blue: Double(b)/255)
+    }
+}

--- a/Brewpad/Views/InfoView.swift
+++ b/Brewpad/Views/InfoView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct InfoView: View {
+    @EnvironmentObject private var settingsManager: SettingsManager
+
     var body: some View {
         ScrollView {
             VStack(spacing: 30) {
@@ -8,7 +10,7 @@ struct InfoView: View {
                 VStack(spacing: 16) {
                     Image(systemName: "mug.fill")
                         .font(.system(size: 60))
-                        .foregroundColor(.blue)
+                        .foregroundColor(settingsManager.colors.accent)
                     
                     Text("Welcome to Brewpad")
                         .font(.title)
@@ -17,21 +19,21 @@ struct InfoView: View {
                     VStack(spacing: 12) {
                         Text("Your Personal Beverage Recipe Collection")
                             .font(.headline)
-                            .foregroundColor(.blue)
+                            .foregroundColor(settingsManager.colors.accent)
                         
                         Text("Brewpad is your go-to companion for crafting perfect drinks. Whether you're a professional barista or an enthusiastic home brewer, this app helps you discover, organize, and create a variety of beverages.")
                             .multilineTextAlignment(.center)
-                            .foregroundColor(.gray)
+                            .foregroundColor(settingsManager.colors.textSecondary)
                         
                         Text("Browse through our carefully curated collection of recipes across different categories - from coffee and tea to chocolate and specialty drinks. Each recipe includes detailed instructions, ingredients, and preparation steps to help you make the perfect drink every time.")
                             .multilineTextAlignment(.center)
-                            .foregroundColor(.gray)
+                            .foregroundColor(settingsManager.colors.textSecondary)
                     }
                 }
                 .padding()
                 .frame(maxWidth: .infinity)
                 .background(RoundedRectangle(cornerRadius: 12)
-                    .fill(Color.gray.opacity(0.05)))
+                    .fill(settingsManager.colors.divider.opacity(0.2)))
                 
                 // Credits & Base Recipe Section
                 VStack(spacing: 16) {
@@ -42,11 +44,11 @@ struct InfoView: View {
                     VStack(spacing: 12) {
                         Text("Base Espresso Recipe")
                             .font(.headline)
-                            .foregroundColor(.blue)
+                            .foregroundColor(settingsManager.colors.accent)
                         
                         Text("All coffee-based recipes use the base espresso recipe from Artisti Coffee Roasters:")
                             .multilineTextAlignment(.center)
-                            .foregroundColor(.gray)
+                            .foregroundColor(settingsManager.colors.textSecondary)
                             .frame(maxWidth: .infinity)
                         
                         VStack(alignment: .leading, spacing: 8) {
@@ -55,7 +57,7 @@ struct InfoView: View {
                             Text("• Extract 45g espresso (double shot)")
                         }
                         .font(.subheadline)
-                        .foregroundColor(.gray)
+                        .foregroundColor(settingsManager.colors.textSecondary)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         
                         VStack(spacing: 8) {
@@ -67,10 +69,10 @@ struct InfoView: View {
                                 }
                                 .padding(.horizontal)
                                 .padding(.vertical, 8)
-                                .background(Color.blue.opacity(0.1))
+                                .background(settingsManager.colors.accent.opacity(0.1))
                                 .cornerRadius(8)
                             }
-                            .foregroundColor(.blue)
+                            .foregroundColor(settingsManager.colors.accent)
                             .frame(maxWidth: .infinity)
                             
                             Link(destination: URL(string: "https://www.youtube.com/@ArtistiCoffeeRoasters")!) {
@@ -81,10 +83,10 @@ struct InfoView: View {
                                 }
                                 .padding(.horizontal)
                                 .padding(.vertical, 8)
-                                .background(Color.blue.opacity(0.1))
+                                .background(settingsManager.colors.accent.opacity(0.1))
                                 .cornerRadius(8)
                             }
-                            .foregroundColor(.blue)
+                            .foregroundColor(settingsManager.colors.accent)
                             .frame(maxWidth: .infinity)
                         }
                         .padding(.top, 4)
@@ -93,7 +95,7 @@ struct InfoView: View {
                 .padding()
                 .frame(maxWidth: .infinity)
                 .background(RoundedRectangle(cornerRadius: 12)
-                    .fill(Color.gray.opacity(0.05)))
+                    .fill(settingsManager.colors.divider.opacity(0.2)))
             }
             .padding()
         }

--- a/Brewpad/Views/OnboardingView.swift
+++ b/Brewpad/Views/OnboardingView.swift
@@ -36,7 +36,7 @@ struct OnboardingView: View {
     
     var body: some View {
         ZStack {
-            Color(uiColor: .systemBackground)
+            settingsManager.colors.background
                 .ignoresSafeArea()
             
             if settingsManager.isReplayingTutorial {
@@ -108,7 +108,7 @@ struct UserSetupView: View {
         VStack(spacing: 30) {
             Image(systemName: "mug.fill")
                 .font(.system(size: 60))
-                .foregroundColor(.blue)
+                .foregroundColor(settingsManager.colors.accent)
             
             Text("Welcome to Brewpad")
                 .font(.title)
@@ -117,11 +117,11 @@ struct UserSetupView: View {
             VStack(spacing: 20) {
                 Text("Your Personal Beverage Guide")
                     .font(.headline)
-                    .foregroundColor(.blue)
+                    .foregroundColor(settingsManager.colors.accent)
                 
                 Text("Join our community of beverage enthusiasts and start your journey to creating perfect drinks.")
                     .font(.subheadline)
-                    .foregroundColor(.gray)
+                    .foregroundColor(settingsManager.colors.textSecondary)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal)
                 
@@ -138,7 +138,7 @@ struct UserSetupView: View {
                         
                         Text("Your name will be used to personalize your experience")
                             .font(.caption)
-                            .foregroundColor(.gray)
+                            .foregroundColor(settingsManager.colors.textSecondary)
                     }
                     
                     // Birth Date
@@ -160,7 +160,7 @@ struct UserSetupView: View {
 
                         Text("Required for accessing alcoholic beverage recipes. You can change this later in settings.")
                             .font(.caption)
-                            .foregroundColor(.gray)
+                            .foregroundColor(settingsManager.colors.textSecondary)
                     }
                 }
             }
@@ -182,7 +182,7 @@ struct TutorialCardView: View {
         VStack(spacing: 30) {
             Image(systemName: card.icon)
                 .font(.system(size: 50))
-                .foregroundColor(.blue)
+                .foregroundColor(settingsManager.colors.accent)
             
             VStack(spacing: 10) {
                 Text(card.title)
@@ -191,7 +191,7 @@ struct TutorialCardView: View {
                 
                 Text(card.description)
                     .font(.body)
-                    .foregroundColor(.gray)
+                    .foregroundColor(settingsManager.colors.textSecondary)
                     .multilineTextAlignment(.center)
             }
         }

--- a/Brewpad/Views/RecipeCard.swift
+++ b/Brewpad/Views/RecipeCard.swift
@@ -47,14 +47,14 @@ struct RecipeCard: View {
                     HStack(spacing: 8) {
                         ForEach(0..<4) { index in
                             Circle()
-                                .fill(selectedSection == index ? Color.blue : Color.gray.opacity(0.3))
+                                .fill(selectedSection == index ? settingsManager.colors.accent : Color.gray.opacity(0.3))
                                 .frame(width: 6, height: 6)
                         }
                     }
                     .padding(.vertical, 8)
                 }
                 .frame(maxWidth: .infinity)
-                .background(Color.gray.opacity(0.05))
+                .background(settingsManager.colors.divider.opacity(0.2))
                 .cornerRadius(10)
                 .transition(
                     .asymmetric(
@@ -78,23 +78,23 @@ struct RecipeCard: View {
                         HStack {
                             Text(recipe.category.rawValue)
                                 .font(.subheadline)
-                                .foregroundColor(.gray)
+                                .foregroundColor(settingsManager.colors.textSecondary)
                             Text("•")
-                                .foregroundColor(.gray)
+                                .foregroundColor(settingsManager.colors.textSecondary)
                             Text("by \(recipe.creator)")
                                 .font(.subheadline)
-                                .foregroundColor(.gray)
+                                .foregroundColor(settingsManager.colors.textSecondary)
                         }
                     }
                     Spacer()
                     Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                        .foregroundColor(.blue)
+                        .foregroundColor(settingsManager.colors.accent)
                         .rotationEffect(.degrees(isExpanded ? 0 : 180))
                         .animation(.spring(response: 0.2), value: isExpanded)
                 }
                 .padding()
                 .frame(maxWidth: .infinity)
-                .background(Color.gray.opacity(0.1))
+                .background(settingsManager.colors.divider.opacity(0.1))
                 .cornerRadius(10)
             }
             .contextMenu {
@@ -129,7 +129,7 @@ struct RecipeCard: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Description")
                 .font(.headline)
-                .foregroundColor(.blue)
+                .foregroundColor(settingsManager.colors.accent)
             Text(recipe.description)
                 .font(.subheadline)
         }
@@ -141,11 +141,11 @@ struct RecipeCard: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Ingredients")
                 .font(.headline)
-                .foregroundColor(.blue)
+                .foregroundColor(settingsManager.colors.accent)
             ForEach(recipe.ingredients, id: \.self) { ingredient in
                 HStack(alignment: .top) {
                     Text("•")
-                        .foregroundColor(.blue)
+                        .foregroundColor(settingsManager.colors.accent)
                     Text(ingredient)
                 }
                 .font(.subheadline)
@@ -159,11 +159,11 @@ struct RecipeCard: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Preparation")
                 .font(.headline)
-                .foregroundColor(.blue)
+                .foregroundColor(settingsManager.colors.accent)
             ForEach(Array(recipe.preparations.enumerated()), id: \.element) { index, step in
                 HStack(alignment: .top) {
                     Text("\(index + 1).")
-                        .foregroundColor(.blue)
+                        .foregroundColor(settingsManager.colors.accent)
                         .frame(width: 25, alignment: .leading)
                     Text(step)
                 }
@@ -179,20 +179,20 @@ struct RecipeCard: View {
             HStack {
                 Text("Notes")
                     .font(.headline)
-                    .foregroundColor(.blue)
+                    .foregroundColor(settingsManager.colors.accent)
                 
                 Spacer()
                 
                 Button(action: { showingNoteSheet = true }) {
                     Label("Add Note", systemImage: "square.and.pencil")
-                        .foregroundColor(.blue)
+                        .foregroundColor(settingsManager.colors.accent)
                 }
             }
             
             if notesManager.getNotesForRecipe(recipe.id).isEmpty {
                 Text("No notes yet")
                     .font(.subheadline)
-                    .foregroundColor(.gray)
+                    .foregroundColor(settingsManager.colors.textSecondary)
                     .italic()
                     .frame(maxWidth: .infinity, alignment: .center)
                     .padding(.top)
@@ -221,13 +221,13 @@ struct NoteBubble: View {
             
             Text(note.dateCreated.formatted(date: .abbreviated, time: .shortened))
                 .font(.caption)
-                .foregroundColor(.gray)
+                .foregroundColor(settingsManager.colors.textSecondary)
         }
         .padding()
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 8)
-                .fill(Color.gray.opacity(0.1))
+                .fill(settingsManager.colors.divider.opacity(0.1))
         )
         .contextMenu {
             Button(role: .destructive) {

--- a/Brewpad/Views/RecipeEditorView.swift
+++ b/Brewpad/Views/RecipeEditorView.swift
@@ -38,7 +38,7 @@ struct RecipeEditorView: View {
                     VStack(alignment: .leading, spacing: 12) {
                         Text("Basic Information")
                             .font(.headline)
-                            .foregroundColor(.blue)
+                            .foregroundColor(settingsManager.colors.accent)
                         
                         TextField("Recipe Name", text: $recipeName)
                             .textFieldStyle(RoundedBorderTextFieldStyle())
@@ -56,18 +56,18 @@ struct RecipeEditorView: View {
                     }
                     .padding()
                     .background(RoundedRectangle(cornerRadius: 12)
-                        .fill(Color.gray.opacity(0.05)))
+                        .fill(settingsManager.colors.divider.opacity(0.2)))
                     
                     // Ingredients Section
                     VStack(alignment: .leading, spacing: 12) {
                         HStack {
                             Text("Ingredients")
                                 .font(.headline)
-                                .foregroundColor(.blue)
+                                .foregroundColor(settingsManager.colors.accent)
                             Spacer()
                             Button(action: { ingredients.append("") }) {
                                 Image(systemName: "plus.circle.fill")
-                                    .foregroundColor(.blue)
+                                    .foregroundColor(settingsManager.colors.accent)
                             }
                         }
                         
@@ -87,25 +87,25 @@ struct RecipeEditorView: View {
                     }
                     .padding()
                     .background(RoundedRectangle(cornerRadius: 12)
-                        .fill(Color.gray.opacity(0.05)))
+                        .fill(settingsManager.colors.divider.opacity(0.2)))
                     
                     // Preparation Steps Section
                     VStack(alignment: .leading, spacing: 12) {
                         HStack {
                             Text("Preparation Steps")
                                 .font(.headline)
-                                .foregroundColor(.blue)
+                                .foregroundColor(settingsManager.colors.accent)
                             Spacer()
                             Button(action: { preparations.append("") }) {
                                 Image(systemName: "plus.circle.fill")
-                                    .foregroundColor(.blue)
+                                    .foregroundColor(settingsManager.colors.accent)
                             }
                         }
                         
                         ForEach(preparations.indices, id: \.self) { index in
                             HStack {
                                 Text("\(index + 1).")
-                                    .foregroundColor(.blue)
+                                    .foregroundColor(settingsManager.colors.accent)
                                     .frame(width: 25, alignment: .leading)
                                 
                                 TextField("Step \(index + 1)", text: $preparations[index], axis: .vertical)
@@ -123,7 +123,7 @@ struct RecipeEditorView: View {
                     }
                     .padding()
                     .background(RoundedRectangle(cornerRadius: 12)
-                        .fill(Color.gray.opacity(0.05)))
+                        .fill(settingsManager.colors.divider.opacity(0.2)))
                     
                     // Save Button
                     Button(action: saveRecipe) {
@@ -134,7 +134,7 @@ struct RecipeEditorView: View {
                             .padding()
                             .background(
                                 RoundedRectangle(cornerRadius: 12)
-                                    .fill(Color.blue.opacity(isFormValid ? 1 : 0.5))
+                                    .fill(settingsManager.colors.buttonBackground.opacity(isFormValid ? 1 : 0.5))
                             )
                     }
                     .disabled(!isFormValid)

--- a/Brewpad/Views/RecipeManagerView.swift
+++ b/Brewpad/Views/RecipeManagerView.swift
@@ -33,6 +33,7 @@ struct ShareSheet: UIViewControllerRepresentable {
 struct RecipeManagerView: View {
     @EnvironmentObject private var recipeStore: RecipeStore
     @EnvironmentObject private var appState: AppState
+    @EnvironmentObject private var settingsManager: SettingsManager
     @State private var selectedAction: RecipeAction?
     @State private var recipeToEdit: Recipe?
     @State private var recipeToExport: Recipe?
@@ -65,7 +66,7 @@ struct RecipeManagerView: View {
                     .foregroundColor(.white)
                     .frame(maxWidth: .infinity)
                     .padding()
-                    .background(Color.blue)
+                    .background(settingsManager.colors.buttonBackground)
                     .cornerRadius(10)
                 }
                 
@@ -80,7 +81,7 @@ struct RecipeManagerView: View {
                     .foregroundColor(.white)
                     .frame(maxWidth: .infinity)
                     .padding()
-                    .background(Color.blue)
+                    .background(settingsManager.colors.buttonBackground)
                     .cornerRadius(10)
                 }
                 
@@ -95,7 +96,7 @@ struct RecipeManagerView: View {
                     .foregroundColor(.white)
                     .frame(maxWidth: .infinity)
                     .padding()
-                    .background(Color.blue)
+                    .background(settingsManager.colors.buttonBackground)
                     .cornerRadius(10)
                 }
                 
@@ -110,7 +111,7 @@ struct RecipeManagerView: View {
                     .foregroundColor(.white)
                     .frame(maxWidth: .infinity)
                     .padding()
-                    .background(Color.blue)
+                    .background(settingsManager.colors.buttonBackground)
                     .cornerRadius(10)
                 }
                 
@@ -120,28 +121,28 @@ struct RecipeManagerView: View {
                 VStack(spacing: 12) {
                     Text("Recipe Management")
                         .font(.headline)
-                        .foregroundColor(.gray)
+                        .foregroundColor(settingsManager.colors.textSecondary)
                     
                     Text("Create, edit, import, and export your custom recipes. Imported recipes will be added to your personal collection.")
                         .font(.caption)
-                        .foregroundColor(.gray)
+                        .foregroundColor(settingsManager.colors.textSecondary)
                         .multilineTextAlignment(.center)
                     
                     Text("Important Information")
                         .font(.subheadline)
-                        .foregroundColor(.gray)
+                        .foregroundColor(settingsManager.colors.textSecondary)
                         .padding(.top, 4)
                     
                     Text("• Importing recipes is done at your own risk. Only import files from trusted sources.\n\n• Editing recipe files outside the app is not supported and may cause errors.\n\n• Sharing recipes with others is your responsibility. Be mindful of what you share.")
                         .font(.caption)
-                        .foregroundColor(.gray)
+                        .foregroundColor(settingsManager.colors.textSecondary)
                         .multilineTextAlignment(.leading)
                 }
                 .padding(.horizontal)
                 .frame(maxWidth: .infinity)
                 .background(
                     RoundedRectangle(cornerRadius: 12)
-                        .fill(Color.gray.opacity(0.05))
+                        .fill(settingsManager.colors.divider.opacity(0.2))
                         .padding(.horizontal)
                 )
             }
@@ -301,6 +302,7 @@ struct ActionButton: View {
     let title: String
     let icon: String
     let action: () -> Void
+    @EnvironmentObject private var settingsManager: SettingsManager
     
     var body: some View {
         Button(action: action) {
@@ -309,13 +311,13 @@ struct ActionButton: View {
                 Text(title)
                 Spacer()
                 Image(systemName: "chevron.right")
-                    .foregroundColor(.gray)
+                    .foregroundColor(settingsManager.colors.textSecondary)
             }
-            .foregroundColor(.blue)
+            .foregroundColor(settingsManager.colors.buttonText)
             .padding()
-            .background(Color.white)
+            .background(settingsManager.colors.buttonBackground)
             .cornerRadius(10)
-            .shadow(color: .gray.opacity(0.1), radius: 2, x: 0, y: 1)
+            .shadow(color: settingsManager.colors.divider.opacity(0.1), radius: 2, x: 0, y: 1)
         }
     }
 }
@@ -341,7 +343,7 @@ struct RecipeListView: View {
                             .font(.headline)
                         Text(recipe.category.rawValue)
                             .font(.subheadline)
-                            .foregroundColor(.gray)
+                            .foregroundColor(settingsManager.colors.textSecondary)
                     }
                 }
                 .contextMenu {

--- a/Brewpad/Views/RecipesView.swift
+++ b/Brewpad/Views/RecipesView.swift
@@ -45,7 +45,7 @@ struct RecipesView: View {
                         .padding(.trailing)
                     }
                     .padding(.vertical, 8)
-                    .background(Color.gray.opacity(0.1))
+                    .background(settingsManager.colors.divider.opacity(0.1))
                     .transition(.move(edge: .trailing))
                 } else {
                     HStack(spacing: 0) {
@@ -76,15 +76,15 @@ struct RecipesView: View {
                         .padding(.trailing)
                     }
                     .padding(.vertical, 8)
-                    .background(Color.gray.opacity(0.1))
+                    .background(settingsManager.colors.divider.opacity(0.1))
 
                     if let description = categoryDescriptions[categories[selectedCategory]] {
                         Text(description)
                             .font(.subheadline)
-                            .foregroundColor(.gray)
+                            .foregroundColor(settingsManager.colors.textSecondary)
                             .padding()
                             .frame(maxWidth: .infinity)
-                            .background(Color.gray.opacity(0.05))
+                            .background(settingsManager.colors.divider.opacity(0.2))
                             .transition(.opacity)
                             .animation(.easeInOut, value: selectedCategory)
                     }
@@ -141,6 +141,7 @@ struct CategoryTab: View {
     let isSelected: Bool
     let animation: Namespace.ID
     let action: () -> Void
+    @EnvironmentObject private var settingsManager: SettingsManager
     
     var body: some View {
         Button(action: action) {
@@ -148,7 +149,7 @@ struct CategoryTab: View {
                 .font(.subheadline)
                 .padding(.horizontal, 16)
                 .padding(.vertical, 8)
-                .foregroundColor(isSelected ? .blue : .primary)
+                .foregroundColor(isSelected ? settingsManager.colors.accent : .primary)
         }
     }
 }

--- a/Brewpad/Views/SettingsView.swift
+++ b/Brewpad/Views/SettingsView.swift
@@ -76,14 +76,14 @@ struct SettingsView: View {
                                     isEditingUsername = true
                                 }) {
                                     Image(systemName: "pencil.circle.fill")
-                                        .foregroundColor(.blue)
+                                        .foregroundColor(settingsManager.colors.accent)
                                 }
                             }
                         }
                         
                         Text("Your display name in the app")
                             .font(.caption)
-                            .foregroundColor(.gray)
+                            .foregroundColor(settingsManager.colors.textSecondary)
                     }
                     
                     Divider()
@@ -107,12 +107,12 @@ struct SettingsView: View {
 
                         Text("Required for accessing alcoholic beverage recipes")
                             .font(.caption)
-                            .foregroundColor(.gray)
+                            .foregroundColor(settingsManager.colors.textSecondary)
                     }
                 }
                 .padding()
                 .background(RoundedRectangle(cornerRadius: 12)
-                    .fill(Color.gray.opacity(0.05)))
+                    .fill(settingsManager.colors.divider.opacity(0.2)))
                 
                 // App Settings Section
                 VStack(spacing: 16) {
@@ -135,7 +135,7 @@ struct SettingsView: View {
                             
                             Text("Choose your preferred app appearance")
                                 .font(.caption)
-                                .foregroundColor(.gray)
+                                .foregroundColor(settingsManager.colors.textSecondary)
                         }
                         
                         Divider()
@@ -148,15 +148,15 @@ struct SettingsView: View {
                             Toggle(isOn: $settingsManager.useMetricUnits) {
                                 HStack {
                                     Image(systemName: "ruler")
-                                        .foregroundColor(.blue)
+                                        .foregroundColor(settingsManager.colors.accent)
                                     Text(settingsManager.useMetricUnits ? "Metric (ml, g)" : "Imperial (oz, cups)")
                                 }
                             }
-                            .toggleStyle(SwitchToggleStyle(tint: .blue))
+                            .toggleStyle(SwitchToggleStyle(tint: settingsManager.colors.accent))
                             
                             Text("Switch between metric and imperial units for recipe measurements")
                                 .font(.caption)
-                                .foregroundColor(.gray)
+                                .foregroundColor(settingsManager.colors.textSecondary)
                         }
                         
                         Divider()
@@ -180,14 +180,14 @@ struct SettingsView: View {
                                 .foregroundColor(.white)
                                 .frame(maxWidth: .infinity)
                                 .padding()
-                                .background(isDownloading ? Color.gray : Color.blue)
+                                .background(isDownloading ? Color.gray : settingsManager.colors.buttonBackground)
                                 .cornerRadius(10)
                             }
                             .disabled(isDownloading)
                             
                             Text("Download new recipes from our collection")
                                 .font(.caption)
-                                .foregroundColor(.gray)
+                                .foregroundColor(settingsManager.colors.textSecondary)
                         }
                         
                         Divider()
@@ -205,19 +205,19 @@ struct SettingsView: View {
                                 .foregroundColor(.white)
                                 .frame(maxWidth: .infinity)
                                 .padding()
-                                .background(Color.blue)
+                                .background(settingsManager.colors.buttonBackground)
                                 .cornerRadius(10)
                             }
                             
                             Text("View the feature introduction cards again")
                                 .font(.caption)
-                                .foregroundColor(.gray)
+                                .foregroundColor(settingsManager.colors.textSecondary)
                         }
                     }
                 }
                 .padding()
                 .background(RoundedRectangle(cornerRadius: 12)
-                    .fill(Color.gray.opacity(0.05)))
+                    .fill(settingsManager.colors.divider.opacity(0.2)))
                 
                 // Debug Section
                 if settingsManager.isDebugModeEnabled {
@@ -241,7 +241,7 @@ struct SettingsView: View {
                                 
                                 Text("Override the current date for testing holiday messages")
                                     .font(.caption)
-                                    .foregroundColor(.gray)
+                                    .foregroundColor(settingsManager.colors.textSecondary)
                             }
                             
                             Divider()
@@ -267,13 +267,13 @@ struct SettingsView: View {
                                     .foregroundColor(.white)
                                     .frame(maxWidth: .infinity)
                                     .padding()
-                                    .background(Color.blue)
+                                    .background(settingsManager.colors.buttonBackground)
                                     .cornerRadius(10)
                                 }
                                 
                                 Text("Restart the complete onboarding process, including username and age verification")
                                     .font(.caption)
-                                    .foregroundColor(.gray)
+                                    .foregroundColor(settingsManager.colors.textSecondary)
                             }
                             
                             VStack(alignment: .leading, spacing: 8) {
@@ -285,13 +285,13 @@ struct SettingsView: View {
                                         Text("Recipe Debug Info")
                                         Spacer()
                                         Image(systemName: "chevron.right")
-                                            .foregroundColor(.gray)
+                                            .foregroundColor(settingsManager.colors.textSecondary)
                                     }
                                 }
 
                                 Text("View detailed recipe information")
                                     .font(.caption)
-                                    .foregroundColor(.gray)
+                                    .foregroundColor(settingsManager.colors.textSecondary)
                             }
 
                             // Server Response
@@ -302,11 +302,11 @@ struct SettingsView: View {
                                 if let response = recipeStore.serverResponse {
                                     Text(response)
                                         .font(.caption)
-                                        .foregroundColor(.gray)
+                                        .foregroundColor(settingsManager.colors.textSecondary)
                                 } else {
                                     Text("No response yet")
                                         .font(.caption)
-                                        .foregroundColor(.gray)
+                                        .foregroundColor(settingsManager.colors.textSecondary)
                                 }
 
                                 if !recipeStore.serverFetchedRecipes.isEmpty {
@@ -316,7 +316,7 @@ struct SettingsView: View {
                                         ForEach(recipeStore.serverFetchedRecipes, id: \.self) { recipe in
                                             Text(recipe)
                                                 .font(.caption2)
-                                                .foregroundColor(.gray)
+                                                .foregroundColor(settingsManager.colors.textSecondary)
                                         }
                                     }
                                 }
@@ -329,7 +329,7 @@ struct SettingsView: View {
                                     .foregroundColor(.white)
                                     .frame(maxWidth: .infinity)
                                     .padding()
-                                    .background(Color.blue)
+                                    .background(settingsManager.colors.buttonBackground)
                                     .cornerRadius(10)
                                 }
                             }
@@ -339,19 +339,19 @@ struct SettingsView: View {
                     }
                     .padding()
                     .background(RoundedRectangle(cornerRadius: 12)
-                        .fill(Color.gray.opacity(0.05)))
+                        .fill(settingsManager.colors.divider.opacity(0.2)))
                 }
                 
                 // Copyright Notice
                 VStack(spacing: 4) {
                     Text("© \(Calendar.current.component(.year, from: Date()))")
                         .font(.footnote)
-                        .foregroundColor(.gray)
+                        .foregroundColor(settingsManager.colors.textSecondary)
                     
                     Text("MirreRaven Coding And Design")
                         .font(.footnote)
                         .bold()
-                        .foregroundColor(.gray)
+                        .foregroundColor(settingsManager.colors.textSecondary)
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.vertical)

--- a/Brewpad/Views/TutorialCardsView.swift
+++ b/Brewpad/Views/TutorialCardsView.swift
@@ -10,14 +10,14 @@ struct TutorialCardsView: View {
     
     var body: some View {
         ZStack {
-            Color(uiColor: .systemBackground)
+            settingsManager.colors.background
                 .ignoresSafeArea()
             
             VStack(spacing: 30) {
                 // Welcome Icon
                 Image(systemName: "mug.fill")
                     .font(.system(size: 60))
-                    .foregroundColor(.blue)
+                    .foregroundColor(settingsManager.colors.accent)
                 
                 // Tutorial Cards
                 ZStack {
@@ -113,7 +113,7 @@ struct CardView: View {
         VStack(spacing: 30) {
             Image(systemName: card.icon)
                 .font(.system(size: 50))
-                .foregroundColor(.blue)
+                .foregroundColor(settingsManager.colors.accent)
             
             VStack(spacing: 10) {
                 Text(card.title)
@@ -122,7 +122,7 @@ struct CardView: View {
                 
                 Text(card.description)
                     .font(.body)
-                    .foregroundColor(.gray)
+                    .foregroundColor(settingsManager.colors.textSecondary)
                     .multilineTextAlignment(.center)
             }
         }

--- a/Brewpad/Views/WelcomeScreen.swift
+++ b/Brewpad/Views/WelcomeScreen.swift
@@ -10,7 +10,7 @@ struct WelcomeScreen: View {
             // Welcome Icon
             Image(systemName: "mug.fill")
                 .font(.system(size: 60))
-                .foregroundColor(.blue)
+                .foregroundColor(settingsManager.colors.accent)
             
             // Welcome Text
             Text("Welcome to Brewpad")
@@ -125,7 +125,7 @@ struct FeatureRow: View {
     var body: some View {
         HStack {
             Image(systemName: icon)
-                .foregroundColor(.blue)
+                .foregroundColor(settingsManager.colors.accent)
             Text(text)
         }
     }


### PR DESCRIPTION
## Summary
- add `brewpadDark` case in `Theme`
- provide color palette via new `ThemeColors` struct
- apply theme colors to main views

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840cc2a2f64832abd3c627bdcef972e