### PR TITLE
Fix missing environment object

### DIFF
--- a/Brewpad/Views/OnboardingView.swift
+++ b/Brewpad/Views/OnboardingView.swift
@@ -177,6 +177,7 @@ struct UserSetupView: View {
 
 struct TutorialCardView: View {
     let card: TutorialCard
+    @EnvironmentObject private var settingsManager: SettingsManager
     
     var body: some View {
         VStack(spacing: 30) {

--- a/Brewpad/Views/TutorialCardsView.swift
+++ b/Brewpad/Views/TutorialCardsView.swift
@@ -108,6 +108,7 @@ struct TutorialCardsView: View {
 
 struct CardView: View {
     let card: TutorialCard
+    @EnvironmentObject private var settingsManager: SettingsManager
     
     var body: some View {
         VStack(spacing: 30) {


### PR DESCRIPTION
## Summary
- reference `settingsManager` environment object in tutorial card view components

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840ce964254832a9020bb905fee4351