### PR TITLE
Fix settingsManager scope issues

### DIFF
--- a/Brewpad/Views/WelcomeScreen.swift
+++ b/Brewpad/Views/WelcomeScreen.swift
@@ -121,6 +121,8 @@ struct WelcomeScreen: View {
 struct FeatureRow: View {
     let icon: String
     let text: String
+
+    @EnvironmentObject private var settingsManager: SettingsManager
     
     var body: some View {
         HStack {


### PR DESCRIPTION
## Summary
- use `@EnvironmentObject` in `FeatureRow` so `settingsManager` is available

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840cf5bdf60832ab1dbbca8fda4b3d0