### PR TITLE
Fix missing settings manager in NoteBubble

### DIFF
--- a/Brewpad/Views/RecipeCard.swift
+++ b/Brewpad/Views/RecipeCard.swift
@@ -210,6 +210,7 @@ struct RecipeCard: View {
 }
 
 struct NoteBubble: View {
+    @EnvironmentObject private var settingsManager: SettingsManager
     @EnvironmentObject private var notesManager: NotesManager
     @State private var showingDeleteConfirmation = false
     let note: RecipeNote


### PR DESCRIPTION
## Summary
- add `settingsManager` as an environment object to `NoteBubble`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840d044ef94832ab311e034f6ba3454