### PR TITLE
Fix missing settingsManager in RecipeListView

### DIFF
--- a/Brewpad/Views/RecipeManagerView.swift
+++ b/Brewpad/Views/RecipeManagerView.swift
@@ -326,6 +326,7 @@ struct ActionButton: View {
 struct RecipeListView: View {
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject private var recipeStore: RecipeStore
+    @EnvironmentObject private var settingsManager: SettingsManager
     @State private var showingDeleteConfirmation = false
     @State private var recipeToDelete: Recipe?
     


### PR DESCRIPTION
## Summary
- provide the `settingsManager` EnvironmentObject to RecipeListView

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6840d104b2a0832aaa857852aa1889a9