### PR TITLE
Add Brewpad Light theme

### DIFF
--- a/Brewpad/Managers/SettingsManager.swift
+++ b/Brewpad/Managers/SettingsManager.swift
@@ -60,6 +60,7 @@ class SettingsManager: ObservableObject {
         case system = "System"
         case light = "Light"
         case dark = "Dark"
+        case brewpadLight = "Brewpad Light"
         case brewpadDark = "Brewpad Dark"
         
         var colorScheme: ColorScheme? {
@@ -67,6 +68,7 @@ class SettingsManager: ObservableObject {
             case .system: return nil
             case .light: return .light
             case .dark, .brewpadDark: return .dark
+            case .brewpadLight: return .light
             }
         }
     }
@@ -83,6 +85,7 @@ class SettingsManager: ObservableObject {
         case .light: return ThemeColors.light
         case .dark: return ThemeColors.dark
         case .brewpadDark: return ThemeColors.brewpadDark
+        case .brewpadLight: return ThemeColors.brewpadLight
         }
     }
     

--- a/Brewpad/Utilities/ThemeColors.swift
+++ b/Brewpad/Utilities/ThemeColors.swift
@@ -34,6 +34,17 @@ struct ThemeColors {
         divider: Color(hex: "#3C2A1E"),
         highlight: Color(hex: "#C7A98C")
     )
+
+    static let brewpadLight = ThemeColors(
+        background: Color(hex: "#F9F3EE"),
+        accent: Color(hex: "#6E3B1E"),
+        textPrimary: Color(hex: "#3E2A1B"),
+        textSecondary: Color(hex: "#8B6A53"),
+        buttonBackground: Color(hex: "#D9B49C"),
+        buttonText: Color(hex: "#3E2A1B"),
+        divider: Color(hex: "#E4D6CC"),
+        highlight: Color(hex: "#A67C5B")
+    )
 }
 
 extension Color {

--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ Mark your favorite recipes for easy access anytime.
 
 ### 🌓 Dark & Light Mode Support
 Brewpad features a handcrafted dark and light theme inspired by the app’s iconography and warm, earthy color palettes.
+The new **Brewpad Light** theme uses creamy beige and coffee browns for a soft appearance.


### PR DESCRIPTION
## Summary
- add Brewpad Light color set in `ThemeColors`
- expose new case in settings manager
- document light theme in README

## Testing
- `xcodebuild test -project Brewpad.xcodeproj -scheme Brewpad -destination 'platform=iOS Simulator,name=iPhone 13'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d217d8e4832aaeae311d13fd42ef