### PR TITLE
Add theme picker to onboarding

### DIFF
--- a/Brewpad/Managers/SettingsManager.swift
+++ b/Brewpad/Managers/SettingsManager.swift
@@ -58,8 +58,8 @@ class SettingsManager: ObservableObject {
     
     enum Theme: String, CaseIterable {
         case system = "System"
-        case light = "Light"
-        case dark = "Dark"
+        case light = "iOS Light"
+        case dark = "iOS Dark"
         case brewpadLight = "Brewpad Light"
         case brewpadDark = "Brewpad Dark"
         
@@ -90,9 +90,14 @@ class SettingsManager: ObservableObject {
     }
     
     init() {
-        if let themeString = UserDefaults.standard.string(forKey: "theme"),
-           let savedTheme = Theme(rawValue: themeString) {
-            self.theme = savedTheme
+        if let themeString = UserDefaults.standard.string(forKey: "theme") {
+            if let savedTheme = Theme(rawValue: themeString) {
+                self.theme = savedTheme
+            } else if themeString == "Light" {
+                self.theme = .light
+            } else if themeString == "Dark" {
+                self.theme = .dark
+            }
         }
         
         self.useMetricUnits = UserDefaults.standard.bool(forKey: "useMetricUnits")

--- a/Brewpad/Views/OnboardingView.swift
+++ b/Brewpad/Views/OnboardingView.swift
@@ -44,15 +44,20 @@ struct OnboardingView: View {
                 TutorialCardsView(cards: tutorialCards)
             } else {
                 // Show full onboarding with user setup first
+                let totalSteps = tutorialCards.count + 2
                 TabView(selection: $currentStep) {
                     // User Setup
                     UserSetupView(username: $username)
                         .tag(0)
-                    
+
+                    // Theme Selection
+                    ThemeSelectionView()
+                        .tag(1)
+
                     // Tutorial Cards
                     ForEach(Array(tutorialCards.enumerated()), id: \.element.id) { index, card in
                         TutorialCardView(card: card)
-                            .tag(index + 1)
+                            .tag(index + 2)
                     }
                 }
                 .tabViewStyle(.page)
@@ -73,8 +78,8 @@ struct OnboardingView: View {
                         
                         Spacer()
                         
-                        Button(currentStep == tutorialCards.count ? "Get Started" : "Next") {
-                            if currentStep == tutorialCards.count {
+                        Button(currentStep == totalSteps - 1 ? "Get Started" : "Next") {
+                            if currentStep == totalSteps - 1 {
                                 finishOnboarding()
                             } else {
                                 withAnimation {
@@ -172,6 +177,37 @@ struct UserSetupView: View {
                 isUsernameFocused = true
             }
         }
+    }
+}
+
+struct ThemeSelectionView: View {
+    @EnvironmentObject private var settingsManager: SettingsManager
+
+    var body: some View {
+        VStack(spacing: 30) {
+            Image(systemName: "paintbrush.fill")
+                .font(.system(size: 60))
+                .foregroundColor(settingsManager.colors.accent)
+
+            Text("Choose Your Theme")
+                .font(.title)
+                .bold()
+
+            VStack(spacing: 20) {
+                Text("Mirror your device appearance or select a custom look. You can change this later in Settings.")
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(settingsManager.colors.textSecondary)
+                    .padding(.horizontal)
+
+                Picker("App Theme", selection: $settingsManager.theme) {
+                    ForEach(SettingsManager.Theme.allCases, id: \.self) { theme in
+                        Text(theme.rawValue).tag(theme)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+        }
+        .padding()
     }
 }
 


### PR DESCRIPTION
## Summary
- rename standard Light and Dark themes to iOS Light and iOS Dark
- allow selecting theme during onboarding
- provide compatibility with old theme values

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6840d46f0668832a8de2696f2cb0570d