### PR TITLE
Update recipe card UI and enable live recipe sync

### DIFF
--- a/Brewpad/Models/RecipeStore.swift
+++ b/Brewpad/Models/RecipeStore.swift
@@ -29,7 +29,7 @@ class RecipeStore: ObservableObject {
 
         // Start loading immediately
         loadRecipes()
-        fetchServerRecipes()
+        updateFromServer()
         checkServerConnection()
 
         // Ensure minimum splash screen duration
@@ -67,11 +67,20 @@ class RecipeStore: ObservableObject {
         }.resume()
     }
 
+    /// Public method to manually refresh recipes from the Brewpad server.
+    /// - Parameter completion: Called once the refresh operation has finished.
+    func updateFromServer(completion: (() -> Void)? = nil) {
+        fetchServerRecipes(completion: completion)
+    }
+
     /// Fetches the list of recipes from the Brewpad remote server and downloads
     /// all files found in the index. After downloading, the local recipe list
     /// will be reloaded.
-    private func fetchServerRecipes() {
-        guard let listingURL = URL(string: serverBaseURL) else { return }
+    private func fetchServerRecipes(completion: (() -> Void)? = nil) {
+        guard let listingURL = URL(string: serverBaseURL) else {
+            completion?()
+            return
+        }
 
         print("🔎 Fetching server recipe list from \(listingURL.absoluteString)")
 
@@ -83,6 +92,7 @@ class RecipeStore: ObservableObject {
                     self.hasFetchedServerRecipes = true
                     self.checkInitialization()
                 }
+                completion?()
                 return
             }
 
@@ -108,6 +118,7 @@ class RecipeStore: ObservableObject {
                 DispatchQueue.main.async {
                     self.hasFetchedServerRecipes = true
                     self.loadRecipes()
+                    completion?()
                 }
             }
         }.resume()

--- a/Brewpad/Views/RecipeCard.swift
+++ b/Brewpad/Views/RecipeCard.swift
@@ -100,10 +100,6 @@ struct RecipeCard: View {
                             .scaleEffect(favoriteScale)
                     }
                 }
-                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                    .foregroundColor(settingsManager.colors.accent)
-                    .rotationEffect(.degrees(isExpanded ? 0 : 180))
-                    .animation(.spring(response: 0.2), value: isExpanded)
             }
             .padding()
             .frame(maxWidth: .infinity)

--- a/Brewpad/Views/SettingsView.swift
+++ b/Brewpad/Views/SettingsView.swift
@@ -398,9 +398,8 @@ struct SettingsView: View {
     
     private func downloadRecipes() {
         isDownloading = true
-        
-        // Simulate download with 3 second delay
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+
+        recipeStore.updateFromServer {
             isDownloading = false
             showDownloadComplete = true
         }


### PR DESCRIPTION
## Summary
- remove chevron from recipe cards
- hook recipe update button to the server download logic
- add public method in `RecipeStore` to refresh from the server

## Testing
- `swift test` *(fails: Package.swift missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840d8875134832a8d661175b6e381d7