### PR TITLE
Add tutorial instructions for opening and deleting recipes

### DIFF
--- a/Brewpad/Views/OnboardingView.swift
+++ b/Brewpad/Views/OnboardingView.swift
@@ -31,6 +31,11 @@ struct OnboardingView: View {
             title: "Growing Collection",
             description: "Brewpad is constantly evolving! Look forward to regular recipe additions, seasonal specials, and community favorites. Check back often to discover new drinks and brewing techniques.",
             icon: "sparkles"
+        ),
+        TutorialCard(
+            title: "Using Recipe Cards",
+            description: "Tap a card to open its recipe. To delete one of your own recipes, tap and hold the card until the menu appears. This option is only available for recipes you've created.",
+            icon: "hand.tap"
         )
     ]
     


### PR DESCRIPTION
## Summary
- expand the tutorial sequence in OnboardingView with a new card
  - explains tapping to open recipes
  - explains long press to delete user-created recipes

## Testing
- `xcodebuild -list -project Brewpad.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d9de2484832aa53cb8d2c3dec77f