### PR TITLE
Add dynamic metric/imperial unit conversion

### DIFF
--- a/Brewpad/Utils/MeasurementConverter.swift
+++ b/Brewpad/Utils/MeasurementConverter.swift
@@ -1,7 +1,8 @@
 import Foundation
 
 struct MeasurementConverter {
-    private static let weightRegex: NSRegularExpression = {
+    // MARK: - Regular Expressions
+    private static let metricWeightRegex: NSRegularExpression = {
         guard let regex = try? NSRegularExpression(
             pattern: "([0-9]+\\.?[0-9]*)g\\b",
             options: []
@@ -10,7 +11,8 @@ struct MeasurementConverter {
         }
         return regex
     }()
-    private static let volumeRegex: NSRegularExpression = {
+
+    private static let metricVolumeRegex: NSRegularExpression = {
         guard let regex = try? NSRegularExpression(
             pattern: "([0-9]+\\.?[0-9]*)ml\\b",
             options: []
@@ -19,7 +21,8 @@ struct MeasurementConverter {
         }
         return regex
     }()
-    private static let temperatureRegex: NSRegularExpression = {
+
+    private static let metricTemperatureRegex: NSRegularExpression = {
         guard let regex = try? NSRegularExpression(
             pattern: "([0-9]+\\.?[0-9]*)°C\\b",
             options: []
@@ -28,7 +31,8 @@ struct MeasurementConverter {
         }
         return regex
     }()
-    private static let lengthRegex: NSRegularExpression = {
+
+    private static let metricLengthRegex: NSRegularExpression = {
         guard let regex = try? NSRegularExpression(
             pattern: "([0-9]+\\.?[0-9]*)cm\\b",
             options: []
@@ -38,34 +42,75 @@ struct MeasurementConverter {
         return regex
     }()
 
-    private static let patterns: [(NSRegularExpression, (Double) -> String)] = [
-        // Weight: grams
+    private static let imperialWeightRegex: NSRegularExpression = {
+        guard let regex = try? NSRegularExpression(
+            pattern: "([0-9]+\\.?[0-9]*) ?oz\\b",
+            options: []
+        ) else {
+            fatalError("Failed to compile imperial weight regular expression")
+        }
+        return regex
+    }()
+
+    private static let imperialVolumeRegex: NSRegularExpression = {
+        guard let regex = try? NSRegularExpression(
+            pattern: "([0-9]+\\.?[0-9]*) ?fl oz\\b",
+            options: []
+        ) else {
+            fatalError("Failed to compile imperial volume regular expression")
+        }
+        return regex
+    }()
+
+    private static let imperialTemperatureRegex: NSRegularExpression = {
+        guard let regex = try? NSRegularExpression(
+            pattern: "([0-9]+\\.?[0-9]*)°F\\b",
+            options: []
+        ) else {
+            fatalError("Failed to compile imperial temperature regular expression")
+        }
+        return regex
+    }()
+
+    private static let imperialLengthRegex: NSRegularExpression = {
+        guard let regex = try? NSRegularExpression(
+            pattern: "([0-9]+\\.?[0-9]*) ?inches?\\b",
+            options: []
+        ) else {
+            fatalError("Failed to compile imperial length regular expression")
+        }
+        return regex
+    }()
+
+    // MARK: - Conversion Patterns
+    private static let metricToImperial: [(NSRegularExpression, (Double) -> String)] = [
+        // Weight: grams to ounces
         (
-            weightRegex,
+            metricWeightRegex,
             { value in
                 let oz = value * 0.035274
                 return String(format: "%.1f oz", oz)
             }
         ),
-        // Volume: milliliters
+        // Volume: milliliters to fluid ounces
         (
-            volumeRegex,
+            metricVolumeRegex,
             { value in
                 let flOz = value * 0.033814
                 return String(format: "%.1f fl oz", flOz)
             }
         ),
-        // Temperature: Celsius
+        // Temperature: Celsius to Fahrenheit
         (
-            temperatureRegex,
+            metricTemperatureRegex,
             { value in
                 let fahrenheit = (value * 9/5) + 32
                 return String(format: "%.0f°F", fahrenheit)
             }
         ),
-        // Length: centimeters
+        // Length: centimeters to inches
         (
-            lengthRegex,
+            metricLengthRegex,
             { value in
                 let inches = value * 0.393701
                 return String(format: "%.1f inches", inches)
@@ -73,27 +118,58 @@ struct MeasurementConverter {
         )
     ]
 
+    private static let imperialToMetric: [(NSRegularExpression, (Double) -> String)] = [
+        // Weight: ounces to grams
+        (
+            imperialWeightRegex,
+            { value in
+                let grams = value / 0.035274
+                return String(format: "%.0fg", grams)
+            }
+        ),
+        // Volume: fluid ounces to milliliters
+        (
+            imperialVolumeRegex,
+            { value in
+                let ml = value / 0.033814
+                return String(format: "%.0fml", ml)
+            }
+        ),
+        // Temperature: Fahrenheit to Celsius
+        (
+            imperialTemperatureRegex,
+            { value in
+                let celsius = (value - 32) * 5/9
+                return String(format: "%.0f°C", celsius)
+            }
+        ),
+        // Length: inches to centimeters
+        (
+            imperialLengthRegex,
+            { value in
+                let cm = value / 0.393701
+                return String(format: "%.1fcm", cm)
+            }
+        )
+    ]
+
+    // MARK: - Public API
     static func convert(_ text: String, toImperial: Bool) -> String {
-        
         var result = text
-
-        if toImperial {
-            for (regex, converter) in patterns {
-                let nsRange = NSRange(result.startIndex..<result.endIndex, in: result)
-
-                // Find all matches and process them in reverse order
-                let matches = regex.matches(in: result, options: [], range: nsRange)
-                for match in matches.reversed() {
-                    if let fullRange = Range(match.range, in: result),
-                       let valueRange = Range(match.range(at: 1), in: result),
-                       let value = Double(result[valueRange]) {
-                        let convertedValue = converter(value)
-                        result.replaceSubrange(fullRange, with: convertedValue)
-                    }
+        let patterns = toImperial ? metricToImperial : imperialToMetric
+        for (regex, converter) in patterns {
+            let nsRange = NSRange(result.startIndex..<result.endIndex, in: result)
+            // Find all matches and process them in reverse order
+            let matches = regex.matches(in: result, options: [], range: nsRange)
+            for match in matches.reversed() {
+                if let fullRange = Range(match.range, in: result),
+                   let valueRange = Range(match.range(at: 1), in: result),
+                   let value = Double(result[valueRange]) {
+                    let convertedValue = converter(value)
+                    result.replaceSubrange(fullRange, with: convertedValue)
                 }
             }
         }
-        
         return result
     }
-} 
+}

--- a/Brewpad/Views/RecipeCard.swift
+++ b/Brewpad/Views/RecipeCard.swift
@@ -156,7 +156,12 @@ struct RecipeCard: View {
                 HStack(alignment: .top) {
                     Text("•")
                         .foregroundColor(settingsManager.colors.accent)
-                    Text(ingredient)
+                    Text(
+                        MeasurementConverter.convert(
+                            ingredient,
+                            toImperial: !settingsManager.useMetricUnits
+                        )
+                    )
                 }
                 .font(.subheadline)
             }
@@ -175,7 +180,12 @@ struct RecipeCard: View {
                     Text("\(index + 1).")
                         .foregroundColor(settingsManager.colors.accent)
                         .frame(width: 25, alignment: .leading)
-                    Text(step)
+                    Text(
+                        MeasurementConverter.convert(
+                            step,
+                            toImperial: !settingsManager.useMetricUnits
+                        )
+                    )
                 }
                 .font(.subheadline)
             }

--- a/BrewpadTests/MeasurementConverterTests.swift
+++ b/BrewpadTests/MeasurementConverterTests.swift
@@ -9,9 +9,21 @@ struct MeasurementConverterTests {
     }
 
     @Test
+    func testOuncesToGrams() async throws {
+        let result = MeasurementConverter.convert("0.7 oz", toImperial: false)
+        #expect(result.contains("20g"))
+    }
+
+    @Test
     func testMillilitersToFluidOunces() async throws {
         let result = MeasurementConverter.convert("120ml", toImperial: true)
         #expect(result.contains("4.1 fl oz"))
+    }
+
+    @Test
+    func testFluidOuncesToMilliliters() async throws {
+        let result = MeasurementConverter.convert("4 fl oz", toImperial: false)
+        #expect(result.contains("118ml"))
     }
 
     @Test
@@ -21,9 +33,21 @@ struct MeasurementConverterTests {
     }
 
     @Test
+    func testFahrenheitToCelsius() async throws {
+        let result = MeasurementConverter.convert("199°F", toImperial: false)
+        #expect(result.contains("93°C"))
+    }
+
+    @Test
     func testCentimetersToInches() async throws {
         let result = MeasurementConverter.convert("20cm", toImperial: true)
         #expect(result.contains("7.9 inches"))
+    }
+
+    @Test
+    func testInchesToCentimeters() async throws {
+        let result = MeasurementConverter.convert("7.9 inches", toImperial: false)
+        #expect(result.contains("20.0cm"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- implement bi-directional conversion in `MeasurementConverter`
- update `RecipeCard` to convert recipe text based on unit preference
- extend unit tests for imperial to metric conversions

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840de32d98c832ab83b1968146c71ae