### PR TITLE
Improve unit converter range support

### DIFF
--- a/Brewpad/Utils/MeasurementConverter.swift
+++ b/Brewpad/Utils/MeasurementConverter.swift
@@ -12,6 +12,16 @@ struct MeasurementConverter {
         return regex
     }()
 
+    private static let metricKilogramRegex: NSRegularExpression = {
+        guard let regex = try? NSRegularExpression(
+            pattern: "([0-9]+\\.?[0-9]*)kg\\b",
+            options: []
+        ) else {
+            fatalError("Failed to compile kilogram regular expression")
+        }
+        return regex
+    }()
+
     private static let metricVolumeRegex: NSRegularExpression = {
         guard let regex = try? NSRegularExpression(
             pattern: "([0-9]+\\.?[0-9]*)ml\\b",
@@ -52,6 +62,16 @@ struct MeasurementConverter {
         return regex
     }()
 
+    private static let imperialPoundRegex: NSRegularExpression = {
+        guard let regex = try? NSRegularExpression(
+            pattern: "([0-9]+\\.?[0-9]*) ?lbs?\\b",
+            options: []
+        ) else {
+            fatalError("Failed to compile pound regular expression")
+        }
+        return regex
+    }()
+
     private static let imperialVolumeRegex: NSRegularExpression = {
         guard let regex = try? NSRegularExpression(
             pattern: "([0-9]+\\.?[0-9]*) ?fl oz\\b",
@@ -82,6 +102,27 @@ struct MeasurementConverter {
         return regex
     }()
 
+    // Range patterns (e.g., 10-15g)
+    private static let metricRangeRegex: NSRegularExpression = {
+        guard let regex = try? NSRegularExpression(
+            pattern: "([0-9]+\\.?[0-9]*)\\s*-\\s*([0-9]+\\.?[0-9]*)(g|kg|ml)\\b",
+            options: []
+        ) else {
+            fatalError("Failed to compile metric range regular expression")
+        }
+        return regex
+    }()
+
+    private static let imperialRangeRegex: NSRegularExpression = {
+        guard let regex = try? NSRegularExpression(
+            pattern: "([0-9]+\\.?[0-9]*)\\s*-\\s*([0-9]+\\.?[0-9]*)(oz|fl oz|lbs?)\\b",
+            options: []
+        ) else {
+            fatalError("Failed to compile imperial range regular expression")
+        }
+        return regex
+    }()
+
     // MARK: - Conversion Patterns
     private static let metricToImperial: [(NSRegularExpression, (Double) -> String)] = [
         // Weight: grams to ounces
@@ -90,6 +131,14 @@ struct MeasurementConverter {
             { value in
                 let oz = value * 0.035274
                 return String(format: "%.1f oz", oz)
+            }
+        ),
+        // Weight: kilograms to pounds
+        (
+            metricKilogramRegex,
+            { value in
+                let pounds = value * 2.20462
+                return String(format: "%.1f lb", pounds)
             }
         ),
         // Volume: milliliters to fluid ounces
@@ -127,6 +176,14 @@ struct MeasurementConverter {
                 return String(format: "%.0fg", grams)
             }
         ),
+        // Weight: pounds to kilograms
+        (
+            imperialPoundRegex,
+            { value in
+                let kg = value / 2.20462
+                return String(format: "%.1fkg", kg)
+            }
+        ),
         // Volume: fluid ounces to milliliters
         (
             imperialVolumeRegex,
@@ -156,6 +213,8 @@ struct MeasurementConverter {
     // MARK: - Public API
     static func convert(_ text: String, toImperial: Bool) -> String {
         var result = text
+        // First handle ranges like "10-15g" so both numbers are converted
+        result = convertRanges(result, toImperial: toImperial)
         let patterns = toImperial ? metricToImperial : imperialToMetric
         for (regex, converter) in patterns {
             let nsRange = NSRange(result.startIndex..<result.endIndex, in: result)
@@ -169,6 +228,66 @@ struct MeasurementConverter {
                     result.replaceSubrange(fullRange, with: convertedValue)
                 }
             }
+        }
+        return result
+    }
+
+    private static func convertRanges(_ text: String, toImperial: Bool) -> String {
+        var result = text
+        let regex = toImperial ? metricRangeRegex : imperialRangeRegex
+        let nsRange = NSRange(result.startIndex..<result.endIndex, in: result)
+        let matches = regex.matches(in: result, options: [], range: nsRange)
+        for match in matches.reversed() {
+            guard let fullRange = Range(match.range, in: result),
+                  let firstValueRange = Range(match.range(at: 1), in: result),
+                  let secondValueRange = Range(match.range(at: 2), in: result),
+                  let unitRange = Range(match.range(at: 3), in: result),
+                  let firstValue = Double(result[firstValueRange]),
+                  let secondValue = Double(result[secondValueRange]) else { continue }
+
+            let unit = String(result[unitRange])
+            var convertedUnit: String = unit
+            var newFirst: String = String(firstValue)
+            var newSecond: String = String(secondValue)
+
+            if toImperial {
+                switch unit {
+                case "g":
+                    newFirst = String(format: "%.1f", firstValue * 0.035274)
+                    newSecond = String(format: "%.1f", secondValue * 0.035274)
+                    convertedUnit = "oz"
+                case "kg":
+                    newFirst = String(format: "%.1f", firstValue * 2.20462)
+                    newSecond = String(format: "%.1f", secondValue * 2.20462)
+                    convertedUnit = "lb"
+                case "ml":
+                    newFirst = String(format: "%.1f", firstValue * 0.033814)
+                    newSecond = String(format: "%.1f", secondValue * 0.033814)
+                    convertedUnit = "fl oz"
+                default:
+                    break
+                }
+            } else {
+                switch unit {
+                case "oz":
+                    newFirst = String(format: "%.0f", firstValue / 0.035274)
+                    newSecond = String(format: "%.0f", secondValue / 0.035274)
+                    convertedUnit = "g"
+                case "fl oz":
+                    newFirst = String(format: "%.0f", firstValue / 0.033814)
+                    newSecond = String(format: "%.0f", secondValue / 0.033814)
+                    convertedUnit = "ml"
+                case "lb", "lbs":
+                    newFirst = String(format: "%.1f", firstValue / 2.20462)
+                    newSecond = String(format: "%.1f", secondValue / 2.20462)
+                    convertedUnit = "kg"
+                default:
+                    break
+                }
+            }
+
+            let replacement = "\(newFirst)-\(newSecond) \(convertedUnit)"
+            result.replaceSubrange(fullRange, with: replacement)
         }
         return result
     }

--- a/Brewpad/Views/InfoView.swift
+++ b/Brewpad/Views/InfoView.swift
@@ -52,9 +52,15 @@ struct InfoView: View {
                             .frame(maxWidth: .infinity)
                         
                         VStack(alignment: .leading, spacing: 8) {
-                            Text("• 22.5g ground coffee (21g basket)")
+                            Text(MeasurementConverter.convert(
+                                "• 22.5g ground coffee (21g basket)",
+                                toImperial: !settingsManager.useMetricUnits
+                            ))
                             Text("• Prep puck as usual")
-                            Text("• Extract 45g espresso (double shot)")
+                            Text(MeasurementConverter.convert(
+                                "• Extract 45g espresso (double shot)",
+                                toImperial: !settingsManager.useMetricUnits
+                            ))
                         }
                         .font(.subheadline)
                         .foregroundColor(settingsManager.colors.textSecondary)


### PR DESCRIPTION
## Summary
- support converting kilograms ↔︎ pounds
- handle ranges like `10-15g` when switching units
- apply unit conversion to Info tab lines

## Testing
- `swiftc -parse-as-library Brewpad/Utils/MeasurementConverter.swift -o /tmp/out.o` *(fails: link command failed but parsing succeeds)*
- `swiftc -parse-as-library Brewpad/Views/InfoView.swift -o /tmp/out.o` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_6840dfa20b60832a84b9c50d14496b7b