### PR TITLE
Implement new featured recipe tags

### DIFF
--- a/Brewpad/Models/Recipe.swift
+++ b/Brewpad/Models/Recipe.swift
@@ -24,7 +24,8 @@ struct Recipe: Identifiable, Codable {
     private let _preparations: [String]
     let isBuiltIn: Bool
     let creator: String
-    let isFeatured: Bool
+    let isWeeklyFeature: Bool
+    let isCommunityHighlight: Bool
 
     /// Public read-only accessors used throughout the views.
     var ingredients: [String] { _ingredients }
@@ -39,7 +40,8 @@ struct Recipe: Identifiable, Codable {
         preparations: [String],
         isBuiltIn: Bool = false,
         creator: String,
-        isFeatured: Bool = false
+        isWeeklyFeature: Bool = false,
+        isCommunityHighlight: Bool = false
     ) {
         self.id = id
         self.name = name
@@ -49,12 +51,13 @@ struct Recipe: Identifiable, Codable {
         self._preparations = preparations
         self.isBuiltIn = isBuiltIn
         self.creator = creator
-        self.isFeatured = isFeatured
+        self.isWeeklyFeature = isWeeklyFeature
+        self.isCommunityHighlight = isCommunityHighlight
     }
 
     // Custom coding keys to map the private stored properties
     private enum CodingKeys: String, CodingKey {
-        case id, name, category, description, ingredients, preparations, isBuiltIn, creator, isFeatured
+        case id, name, category, description, ingredients, preparations, isBuiltIn, creator, isWeeklyFeature, isCommunityHighlight
     }
 
     init(from decoder: Decoder) throws {
@@ -67,7 +70,8 @@ struct Recipe: Identifiable, Codable {
         _preparations = try container.decode([String].self, forKey: .preparations)
         isBuiltIn = try container.decodeIfPresent(Bool.self, forKey: .isBuiltIn) ?? false
         creator = try container.decodeIfPresent(String.self, forKey: .creator) ?? "Unknown"
-        isFeatured = try container.decodeIfPresent(Bool.self, forKey: .isFeatured) ?? false
+        isWeeklyFeature = try container.decodeIfPresent(Bool.self, forKey: .isWeeklyFeature) ?? false
+        isCommunityHighlight = try container.decodeIfPresent(Bool.self, forKey: .isCommunityHighlight) ?? false
     }
 
     func encode(to encoder: Encoder) throws {
@@ -80,6 +84,7 @@ struct Recipe: Identifiable, Codable {
         try container.encode(_preparations, forKey: .preparations)
         try container.encode(isBuiltIn, forKey: .isBuiltIn)
         try container.encode(creator, forKey: .creator)
-        try container.encode(isFeatured, forKey: .isFeatured)
+        try container.encode(isWeeklyFeature, forKey: .isWeeklyFeature)
+        try container.encode(isCommunityHighlight, forKey: .isCommunityHighlight)
     }
 }

--- a/Brewpad/Recipes/cappuccino.json
+++ b/Brewpad/Recipes/cappuccino.json
@@ -2,7 +2,8 @@
     "id": "1b4f8a2e-3d5c-4e6f-9a7b-8c2d1e0f3456",
     "name": "Cappuccino",
     "category": "Coffee",
-    "isFeatured": false,
+    "isWeeklyFeature": false,
+    "isCommunityHighlight": false,
     "description": "A classic espresso-based drink with steamed milk and a light layer of foam. Perfect for morning or afternoon, this drink balances the intensity of coffee with the smoothness of milk.",
     "ingredients": [
         "22.5g ground coffee",

--- a/Brewpad/Recipes/earl_grey.json
+++ b/Brewpad/Recipes/earl_grey.json
@@ -2,7 +2,8 @@
     "id": "2c5b9b3f-4e6d-5f7a-8a9c-1d2e3f4a5678",
     "name": "Earl Grey Tea",
     "category": "Tea",
-    "isFeatured": false,
+    "isWeeklyFeature": false,
+    "isCommunityHighlight": false,
     "description": "A classic black tea flavored with oil of bergamot, offering a distinctive citrus aroma and taste. Perfect for morning or afternoon tea time.",
     "ingredients": [
         "1 Earl Grey tea bag or 2g loose leaf tea",

--- a/Brewpad/Views/ExploreView.swift
+++ b/Brewpad/Views/ExploreView.swift
@@ -4,7 +4,7 @@ struct ExploreView: View {
     @EnvironmentObject var recipeStore: RecipeStore
 
     var featuredRecipes: [Recipe] {
-        recipeStore.recipes.filter { $0.isFeatured }
+        recipeStore.recipes.filter { $0.isWeeklyFeature }
     }
 
     var body: some View {
@@ -34,6 +34,7 @@ struct ExploreView: View {
 
 struct FeaturedRecipeCard: View {
     let recipe: Recipe
+    @EnvironmentObject private var recipeStore: RecipeStore
 
     var body: some View {
         VStack {
@@ -46,6 +47,11 @@ struct FeaturedRecipeCard: View {
 
             Text(recipe.name)
                 .fontWeight(.semibold)
+
+            Button("Import") {
+                recipeStore.importRecipeToPermanent(recipe)
+            }
+            .buttonStyle(.borderedProminent)
         }
         .padding(.vertical)
         .background(Color.white)

--- a/Brewpad/Views/FeaturedRecipesView.swift
+++ b/Brewpad/Views/FeaturedRecipesView.swift
@@ -7,11 +7,11 @@ struct FeaturedRecipesView: View {
     @State private var collapsedCategories: Set<String> = []
 
     private var weeklyRecommendations: [Recipe] {
-        recipeStore.getFeaturedRecipes()
+        recipeStore.getWeeklyFeatures()
     }
 
     private var communityHighlights: [Recipe] {
-        recipeStore.userRecipes
+        recipeStore.getCommunityHighlights()
     }
 
     private var favoriteRecipes: [Recipe] {

--- a/Brewpad/Views/RecipeCard.swift
+++ b/Brewpad/Views/RecipeCard.swift
@@ -99,6 +99,13 @@ struct RecipeCard: View {
                             .rotationEffect(.degrees(favoriteRotation))
                             .scaleEffect(favoriteScale)
                     }
+
+                    Button {
+                        recipeStore.importRecipeToPermanent(recipe)
+                    } label: {
+                        Image(systemName: "tray.and.arrow.down")
+                            .foregroundColor(settingsManager.colors.accent)
+                    }
                 }
             }
             .padding()

--- a/Brewpad/Views/RecipeEditorView.swift
+++ b/Brewpad/Views/RecipeEditorView.swift
@@ -211,7 +211,8 @@ struct RecipeEditorView: View {
             preparations: preparations.filter { !$0.isEmpty },
             isBuiltIn: existingRecipe?.isBuiltIn ?? false,
             creator: isImporting ? existingRecipe?.creator ?? "Unknown" : settingsManager.username ?? "Unknown",
-            isFeatured: existingRecipe?.isFeatured ?? false
+            isWeeklyFeature: existingRecipe?.isWeeklyFeature ?? false,
+            isCommunityHighlight: existingRecipe?.isCommunityHighlight ?? false
         )
         print("📝 Created recipe object: \(recipe.name)")
         

--- a/BrewpadTests/RecipeEditingTests.swift
+++ b/BrewpadTests/RecipeEditingTests.swift
@@ -44,7 +44,8 @@ struct RecipeEditingTests {
                             preparations: ["Brew"],
                             isBuiltIn: original.isBuiltIn,
                             creator: original.creator,
-                            isFeatured: original.isFeatured)
+                            isWeeklyFeature: original.isWeeklyFeature,
+                            isCommunityHighlight: original.isCommunityHighlight)
         try save(edited, existing: original, in: baseDir)
 
         let files = try FileManager.default.contentsOfDirectory(at: baseDir, includingPropertiesForKeys: nil)

--- a/BrewpadTests/RecipeStoreBundledRecipesTests.swift
+++ b/BrewpadTests/RecipeStoreBundledRecipesTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 struct RecipeStoreBundledRecipesTests {
     @Test
-    func testBundledRecipesPreserveIDAndFeatured() async throws {
+    func testBundledRecipesPreserveIDAndFlags() async throws {
         let store = RecipeStore()
         // Wait a moment for recipes to load
         // In tests we assume loading completes synchronously for bundled recipes
@@ -12,11 +12,13 @@ struct RecipeStoreBundledRecipesTests {
         #expect(cappuccino?.creator == "Brewpad")
         #expect(cappuccino?.isBuiltIn == true)
         #expect(cappuccino?.id.uuidString == "1b4f8a2e-3d5c-4e6f-9a7b-8c2d1e0f3456")
-        #expect(cappuccino?.isFeatured == false)
+        #expect(cappuccino?.isWeeklyFeature == false)
+        #expect(cappuccino?.isCommunityHighlight == false)
 
         #expect(earlGrey?.creator == "Brewpad")
         #expect(earlGrey?.isBuiltIn == true)
         #expect(earlGrey?.id.uuidString == "2c5b9b3f-4e6d-5f7a-8a9c-1d2e3f4a5678")
-        #expect(earlGrey?.isFeatured == false)
+        #expect(earlGrey?.isWeeklyFeature == false)
+        #expect(earlGrey?.isCommunityHighlight == false)
     }
 }


### PR DESCRIPTION
## Summary
- introduce `isWeeklyFeature` and `isCommunityHighlight` in `Recipe`
- update `RecipeStore` to handle new feature flags
- adapt explore/featured views to use weekly/community features
- allow importing recipes directly from cards
- update bundled recipes and tests

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840e88e2138832ab7cb5e79746d80d7