### PR TITLE
Restrict featured recipe downloads

### DIFF
--- a/Brewpad/Views/FeaturedRecipesView.swift
+++ b/Brewpad/Views/FeaturedRecipesView.swift
@@ -80,7 +80,8 @@ struct FeaturedRecipesView: View {
                                 RecipeCard(
                                     recipe: recipe,
                                     isExpanded: true,
-                                    onTap: {}
+                                    onTap: {},
+                                    showsDownloadButton: true
                                 )
                                 .frame(width: 300)
                             }

--- a/Brewpad/Views/RecipeCard.swift
+++ b/Brewpad/Views/RecipeCard.swift
@@ -14,6 +14,22 @@ struct RecipeCard: View {
     let recipe: Recipe
     let isExpanded: Bool
     let onTap: () -> Void
+    /// When true, a download button will be shown while the card is expanded.
+    /// This defaults to `false` so the button only appears when explicitly
+    /// requested (e.g. from the Featured tab).
+    let showsDownloadButton: Bool
+
+    init(
+        recipe: Recipe,
+        isExpanded: Bool,
+        onTap: @escaping () -> Void,
+        showsDownloadButton: Bool = false
+    ) {
+        self.recipe = recipe
+        self.isExpanded = isExpanded
+        self.onTap = onTap
+        self.showsDownloadButton = showsDownloadButton
+    }
     
     private let expandedHeight: CGFloat = 300
     
@@ -100,11 +116,13 @@ struct RecipeCard: View {
                             .scaleEffect(favoriteScale)
                     }
 
-                    Button {
-                        recipeStore.importRecipeToPermanent(recipe)
-                    } label: {
-                        Image(systemName: "tray.and.arrow.down")
-                            .foregroundColor(settingsManager.colors.accent)
+                    if showsDownloadButton {
+                        Button {
+                            recipeStore.importRecipeToPermanent(recipe)
+                        } label: {
+                            Image(systemName: "tray.and.arrow.down")
+                                .foregroundColor(settingsManager.colors.accent)
+                        }
                     }
                 }
             }

--- a/Brewpad/Views/RecipeView.swift
+++ b/Brewpad/Views/RecipeView.swift
@@ -41,7 +41,8 @@ struct RecipeView: View {
                                     withAnimation {
                                         expandedRecipeId = expandedRecipeId == recipe.id ? nil : recipe.id
                                     }
-                                }
+                                },
+                                showsDownloadButton: false
                             )
                         }
                     }

--- a/Brewpad/Views/RecipesView.swift
+++ b/Brewpad/Views/RecipesView.swift
@@ -29,6 +29,14 @@ struct RecipesView: View {
         } else {
             base = recipeStore.getRecipesForCategory(categories[selectedCategory])
         }
+
+        // Hide featured recipes unless the user has imported them
+        let downloadedIDs = Set(recipeStore.userRecipes.map(\.id))
+        base.removeAll {
+            ($0.isWeeklyFeature || $0.isCommunityHighlight) &&
+            !downloadedIDs.contains($0.id)
+        }
+
         if showFavoritesOnly {
             base = favoritesManager.favorites(in: base)
         }
@@ -120,7 +128,8 @@ struct RecipesView: View {
                                 withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
                                     expandedRecipe = expandedRecipe == recipe.id ? nil : recipe.id
                                 }
-                            }
+                            },
+                            showsDownloadButton: false
                         )
                     }
                     if showFavoritesOnly && displayedRecipes.isEmpty {


### PR DESCRIPTION
## Summary
- add a `showsDownloadButton` option to `RecipeCard`
- show download button only from `FeaturedRecipesView`
- hide featured recipes in `RecipesView` unless user has downloaded them
- update recipe views to pass new flag

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840ed920cdc832ab292affefbbb2788