### PR TITLE
Limit imported recipe file size

### DIFF
--- a/Brewpad/BrewpadApp.swift
+++ b/Brewpad/BrewpadApp.swift
@@ -33,8 +33,15 @@ struct BrewpadApp: App {
     
     private func handleIncomingURL(_ url: URL) {
         guard url.pathExtension == "brewpadrecipe" else { return }
-        
+
         do {
+            let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+            if let fileSize = attributes[.size] as? NSNumber,
+               fileSize.int64Value > FileLimits.maxRecipeFileSize {
+                print("Incoming recipe exceeds size limit and was ignored")
+                return
+            }
+
             let data = try Data(contentsOf: url)
             let decoder = JSONDecoder()
             let recipe = try decoder.decode(Recipe.self, from: data)

--- a/Brewpad/Models/RecipeStore.swift
+++ b/Brewpad/Models/RecipeStore.swift
@@ -233,6 +233,12 @@ class RecipeStore: ObservableObject {
                 return
             }
 
+            guard data.count <= FileLimits.maxRecipeFileSize else {
+                print("❌ Recipe \(fileName) exceeds size limit and was skipped")
+                completion()
+                return
+            }
+
             print("📥 Downloaded data for \(fileName)")
 
             var recipeData = data
@@ -344,6 +350,12 @@ class RecipeStore: ObservableObject {
     }
     
     private func loadRecipe(from url: URL) throws -> Recipe {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        if let fileSize = attributes[.size] as? NSNumber,
+           fileSize.int64Value > FileLimits.maxRecipeFileSize {
+            throw NSError(domain: "RecipeStore", code: 1, userInfo: [NSLocalizedDescriptionKey: "Recipe file too large"])
+        }
+
         let data = try Data(contentsOf: url)
         var recipe = try JSONDecoder().decode(Recipe.self, from: data)
 

--- a/Brewpad/Utilities/FileLimits.swift
+++ b/Brewpad/Utilities/FileLimits.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct FileLimits {
+    /// Maximum allowed size for imported recipe files (in bytes)
+    static let maxRecipeFileSize = 10 * 1024 * 1024 // 10 MB
+}

--- a/Brewpad/Views/RecipeManagerView.swift
+++ b/Brewpad/Views/RecipeManagerView.swift
@@ -232,6 +232,14 @@ struct RecipeManagerView: View {
                 }
                 
                 do {
+                    let attributes = try FileManager.default.attributesOfItem(atPath: selectedFile.path)
+                    if let fileSize = attributes[.size] as? NSNumber,
+                       fileSize.int64Value > FileLimits.maxRecipeFileSize {
+                        importError = "The selected file exceeds the 10MB limit."
+                        showImportError = true
+                        return
+                    }
+
                     let data = try Data(contentsOf: selectedFile)
                     let decoder = JSONDecoder()
                     var recipe = try decoder.decode(Recipe.self, from: data)


### PR DESCRIPTION
## Summary
- add `FileLimits` for max recipe size constant
- refuse to import recipe files bigger than 10MB
- enforce size check on downloads and loading

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6840ef0584e4832abc8a21c91a76ded5