### PR TITLE
Feature: copy featured recipes

### DIFF
--- a/Brewpad/Models/RecipeStore.swift
+++ b/Brewpad/Models/RecipeStore.swift
@@ -478,11 +478,26 @@ class RecipeStore: ObservableObject {
             try? FileManager.default.createDirectory(at: recipesDirectory, withIntermediateDirectories: true)
         }
 
-        let filename = generateFilename(for: recipe, withExtension: "brewpadrecipe")
+        // Create a fresh copy of the recipe with a new ID and without any
+        // featured flags. The creator is updated so the UI can display the
+        // original author.
+        let copiedRecipe = Recipe(
+            name: recipe.name,
+            category: recipe.category,
+            description: recipe.description,
+            ingredients: recipe.ingredients,
+            preparations: recipe.preparations,
+            isBuiltIn: false,
+            creator: "Copied from \(recipe.creator)",
+            isWeeklyFeature: false,
+            isCommunityHighlight: false
+        )
+
+        let filename = generateFilename(for: copiedRecipe, withExtension: "brewpadrecipe")
         let destinationURL = recipesDirectory.appendingPathComponent(filename)
 
         do {
-            let data = try JSONEncoder().encode(recipe)
+            let data = try JSONEncoder().encode(copiedRecipe)
             try data.write(to: destinationURL)
             print("✅ Imported recipe to \(destinationURL.path)")
             loadRecipes()

--- a/Brewpad/Views/RecipeCard.swift
+++ b/Brewpad/Views/RecipeCard.swift
@@ -99,7 +99,14 @@ struct RecipeCard: View {
                             .foregroundColor(settingsManager.colors.textSecondary)
                         Text("•")
                             .foregroundColor(settingsManager.colors.textSecondary)
-                        Text("by \(recipe.creator)")
+                        let creatorText: String = {
+                            if recipe.creator.lowercased().hasPrefix("copied from") {
+                                return recipe.creator
+                            } else {
+                                return "by \(recipe.creator)"
+                            }
+                        }()
+                        Text(creatorText)
                             .font(.subheadline)
                             .foregroundColor(settingsManager.colors.textSecondary)
                     }


### PR DESCRIPTION
## Summary
- when importing a featured recipe, create a copy with a new ID
- strip featured flags and mark the creator as copied
- show "Copied from" text instead of "by" when listing copied recipes

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68413d4f6880832a86905b4b3c562a8d