### PR TITLE
Disable delete context menu on Featured tab

### DIFF
--- a/Brewpad/Views/FeaturedRecipesView.swift
+++ b/Brewpad/Views/FeaturedRecipesView.swift
@@ -81,7 +81,8 @@ struct FeaturedRecipesView: View {
                                     recipe: recipe,
                                     isExpanded: true,
                                     onTap: {},
-                                    showsDownloadButton: true
+                                    showsDownloadButton: true,
+                                    canDelete: false
                                 )
                                 .frame(width: 300)
                             }

--- a/Brewpad/Views/RecipeCard.swift
+++ b/Brewpad/Views/RecipeCard.swift
@@ -18,17 +18,22 @@ struct RecipeCard: View {
     /// This defaults to `false` so the button only appears when explicitly
     /// requested (e.g. from the Featured tab).
     let showsDownloadButton: Bool
+    /// Controls whether the delete option should be available via the
+    /// long-press context menu. Defaults to `true` for existing behaviour.
+    let canDelete: Bool
 
     init(
         recipe: Recipe,
         isExpanded: Bool,
         onTap: @escaping () -> Void,
-        showsDownloadButton: Bool = false
+        showsDownloadButton: Bool = false,
+        canDelete: Bool = true
     ) {
         self.recipe = recipe
         self.isExpanded = isExpanded
         self.onTap = onTap
         self.showsDownloadButton = showsDownloadButton
+        self.canDelete = canDelete
     }
     
     private let expandedHeight: CGFloat = 300
@@ -140,7 +145,7 @@ struct RecipeCard: View {
             .contentShape(Rectangle())
             .onTapGesture(perform: onTap)
             .contextMenu {
-                if !recipe.isBuiltIn && recipe.creator != "Brewpad" {
+                if canDelete && !recipe.isBuiltIn && recipe.creator != "Brewpad" {
                     Button(role: .destructive) {
                         print("🗑️ Delete button tapped for recipe: \(recipe.name)")
                         showingDeleteConfirmation = true


### PR DESCRIPTION
## Summary
- add a `canDelete` parameter to `RecipeCard` to control deletion
- disable the delete context menu for cards shown in `FeaturedRecipesView`

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68413ea93e48832a9477ea41ab827698