### PR TITLE
Filter out featured recipes from library

### DIFF
--- a/Brewpad/Views/RecipesView.swift
+++ b/Brewpad/Views/RecipesView.swift
@@ -30,16 +30,16 @@ struct RecipesView: View {
             base = recipeStore.getRecipesForCategory(categories[selectedCategory])
         }
 
-        // Hide featured recipes unless the user has imported them
-        let downloadedIDs = Set(recipeStore.userRecipes.map(\.id))
-        base.removeAll {
-            ($0.isWeeklyFeature || $0.isCommunityHighlight) &&
-            !downloadedIDs.contains($0.id)
-        }
-
         if showFavoritesOnly {
             base = favoritesManager.favorites(in: base)
         }
+
+        // Hide featured recipes unless they are a favorite
+        base.removeAll {
+            ($0.isWeeklyFeature || $0.isCommunityHighlight) &&
+            !favoritesManager.isFavorite($0.id)
+        }
+
         return base
     }
     


### PR DESCRIPTION
## Summary
- adjust recipe filtering logic in `RecipesView`
- hide weekly/community feature recipes from the library unless favorited

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68413f8a3868832a9176bb278e0e8193