### PR TITLE
Fix recipe store in Recipes view

### DIFF
--- a/Brewpad/Views/RecipesView.swift
+++ b/Brewpad/Views/RecipesView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct RecipesView: View {
     @EnvironmentObject private var settingsManager: SettingsManager
     @EnvironmentObject private var appState: AppState
-    @StateObject private var recipeStore = RecipeStore()
+    @EnvironmentObject private var recipeStore: RecipeStore
     @EnvironmentObject private var favoritesManager: FavoritesManager
     @State private var selectedCategory = 0
     @State private var expandedRecipe: UUID?


### PR DESCRIPTION
## Summary
- use environment `RecipeStore` instead of instantiating a new one in `RecipesView`

This ensures recipes copied from the Featured tab appear in the main recipe list.

## Testing
- `swift --version`
- `swift test -l` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684140766750832aa85e934b832f1336