### PR TITLE
Add iPad sidebar layout

### DIFF
--- a/Brewpad/Views/RecipesView.swift
+++ b/Brewpad/Views/RecipesView.swift
@@ -6,7 +6,7 @@ struct RecipesView: View {
     @EnvironmentObject private var recipeStore: RecipeStore
     @EnvironmentObject private var favoritesManager: FavoritesManager
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @State private var selectedCategory = 0
+    @Binding var selectedCategory: Int
     @State private var expandedRecipe: UUID?
     @State private var slideDirection: SlideDirection = .none
     @Namespace private var animation
@@ -15,6 +15,10 @@ struct RecipesView: View {
     @State private var searchText = ""
     @State private var showFavoritesOnly = false
     @State private var selectedRecipeId: UUID?
+
+    init(selectedCategory: Binding<Int>) {
+        _selectedCategory = selectedCategory
+    }
     
     enum SlideDirection {
         case left, right, none


### PR DESCRIPTION
## Summary
- introduce new `Tab` enum in `ContentView`
- display `NavigationSplitView` on iPad with sidebar items for app tabs and recipe categories
- factor phone layout into `phoneBody` and reuse `RecipesView` with a bound category
- allow `RecipesView` to accept an external selected category

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841dfe3a64c832a904351271d423277