### PR TITLE
Fix iPad list selection

### DIFF
--- a/Brewpad/ContentView.swift
+++ b/Brewpad/ContentView.swift
@@ -117,11 +117,13 @@ struct ContentView: View {
 
     private var iPadBody: some View {
         NavigationSplitView {
-            List(selection: $selectedTab) {
+            List {
                 Section(header: Text("Tabs")) {
                     ForEach(Tab.allCases) { tab in
-                        Label(tab.title, systemImage: tab.systemImage)
-                            .tag(tab)
+                        Button(action: { selectedTab = tab }) {
+                            Label(tab.title, systemImage: tab.systemImage)
+                        }
+                        .buttonStyle(.plain)
                     }
                 }
 
@@ -129,11 +131,11 @@ struct ContentView: View {
                     Section(header: Text("Categories")) {
                         let categories = ["All"] + Recipe.Category.allCases.map(\.rawValue)
                         ForEach(categories.indices, id: \.self) { index in
-                            Text(categories[index])
-                                .tag(index)
-                                .onTapGesture {
-                                    selectedCategory = index
-                                }
+                            Button(action: { selectedCategory = index }) {
+                                Text(categories[index])
+                            }
+                            .buttonStyle(.plain)
+                            .tag(index)
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- use plain `List` in `NavigationSplitView` for iPad
- handle selection manually to keep iOS compatibility

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841e116b4fc832aaf4c22ec47dcf048