### PR TITLE
Revamp iPad layout

### DIFF
--- a/Brewpad/ContentView.swift
+++ b/Brewpad/ContentView.swift
@@ -117,34 +117,28 @@ struct ContentView: View {
 
     private var iPadBody: some View {
         NavigationSplitView {
-            List {
-                Section(header: Text("Tabs")) {
-                    ForEach(Tab.allCases) { tab in
-                        Button(action: { selectedTab = tab }) {
-                            Label(tab.title, systemImage: tab.systemImage)
-                        }
-                        .buttonStyle(.plain)
-                    }
-                }
-
-                if selectedTab == .recipes {
-                    Section(header: Text("Categories")) {
-                        let categories = ["All"] + Recipe.Category.allCases.map(\.rawValue)
-                        ForEach(categories.indices, id: \.self) { index in
-                            Button(action: { selectedCategory = index }) {
-                                Text(categories[index])
-                            }
-                            .buttonStyle(.plain)
-                            .tag(index)
-                        }
-                    }
+            List(selection: $selectedTab) {
+                ForEach(Tab.allCases) { tab in
+                    Label(tab.title, systemImage: tab.systemImage)
+                        .tag(tab)
                 }
             }
-            .listStyle(.sidebar)
+            .navigationSplitViewColumnWidth(200)
+        } content: {
+            if selectedTab == .recipes {
+                List(selection: $selectedCategory) {
+                    let categories = ["All"] + Recipe.Category.allCases.map(\.rawValue)
+                    ForEach(categories.indices, id: \.self) { index in
+                        Text(categories[index])
+                            .tag(index)
+                    }
+                }
+                .navigationTitle("Categories")
+            }
         } detail: {
             switch selectedTab {
             case .featured:
-                NavigationView { FeaturedRecipesView() }
+                NavigationStack { FeaturedRecipesView() }
             case .recipes:
                 RecipesView(selectedCategory: $selectedCategory)
             case .manage:
@@ -152,7 +146,7 @@ struct ContentView: View {
             case .info:
                 InfoView()
             case .settings:
-                NavigationView {
+                NavigationStack {
                     SettingsView()
                         .navigationTitle("Settings")
                 }

--- a/Brewpad/Views/RecipesView.swift
+++ b/Brewpad/Views/RecipesView.swift
@@ -70,29 +70,30 @@ struct RecipesView: View {
                     TextField("Search recipes", text: $searchText)
                         .textFieldStyle(RoundedBorderTextFieldStyle())
                         .padding(.horizontal)
-                        Spacer()
-                        Button {
-                            withAnimation(.easeInOut) { isSearching.toggle() }
-                            if !isSearching { searchText = "" }
-                        } label: {
-                            Image(systemName: "xmark")
-                        }
-                        .padding(.trailing)
+                    Spacer()
+                    Button {
+                        withAnimation(.easeInOut) { isSearching.toggle() }
+                        if !isSearching { searchText = "" }
+                    } label: {
+                        Image(systemName: "xmark")
                     }
-                    .padding(.vertical, 8)
-                    .background(settingsManager.colors.divider.opacity(0.1))
-                    .transition(.move(edge: .trailing))
-                } else {
-                    HStack(spacing: 0) {
-                        Button {
-                            withAnimation { showFavoritesOnly.toggle() }
-                        } label: {
-                            Image(systemName: showFavoritesOnly ? "star.fill" : "star")
-                                .padding(.leading)
-                                .foregroundColor(settingsManager.colors.accent)
-                        }
-                        .padding(.trailing)
+                    .padding(.trailing)
+                }
+                .padding(.vertical, 8)
+                .background(settingsManager.colors.divider.opacity(0.1))
+                .transition(.move(edge: .trailing))
+            } else {
+                HStack(spacing: 0) {
+                    Button {
+                        withAnimation { showFavoritesOnly.toggle() }
+                    } label: {
+                        Image(systemName: showFavoritesOnly ? "star.fill" : "star")
+                            .padding(.leading)
+                            .foregroundColor(settingsManager.colors.accent)
+                    }
+                    .padding(.trailing)
 
+                    if UIDevice.current.userInterfaceIdiom != .pad {
                         ScrollView(.horizontal, showsIndicators: false) {
                             HStack(spacing: 2) {
                                 ForEach(0..<categories.count, id: \.self) { index in
@@ -111,29 +112,32 @@ struct RecipesView: View {
                             }
                             .padding(.horizontal)
                         }
-                        Button {
-                            withAnimation(.easeInOut) { isSearching.toggle() }
-                            if !isSearching { searchText = "" }
-                        } label: {
-                            Image(systemName: "magnifyingglass")
-                        }
-                        .padding(.leading)
-                        .padding(.trailing)
                     }
-                    .padding(.vertical, 8)
-                    .background(settingsManager.colors.divider.opacity(0.1))
 
-                    if let description = categoryDescriptions[categories[selectedCategory]] {
-                        Text(description)
-                            .font(.subheadline)
-                            .foregroundColor(settingsManager.colors.textSecondary)
-                            .padding()
-                            .frame(maxWidth: .infinity)
-                            .background(settingsManager.colors.divider.opacity(0.2))
-                            .transition(.opacity)
-                            .animation(.easeInOut, value: selectedCategory)
+                    Button {
+                        withAnimation(.easeInOut) { isSearching.toggle() }
+                        if !isSearching { searchText = "" }
+                    } label: {
+                        Image(systemName: "magnifyingglass")
                     }
+                    .padding(.leading)
+                    .padding(.trailing)
                 }
+                .padding(.vertical, 8)
+                .background(settingsManager.colors.divider.opacity(0.1))
+
+                if UIDevice.current.userInterfaceIdiom != .pad,
+                   let description = categoryDescriptions[categories[selectedCategory]] {
+                    Text(description)
+                        .font(.subheadline)
+                        .foregroundColor(settingsManager.colors.textSecondary)
+                        .padding()
+                        .frame(maxWidth: .infinity)
+                        .background(settingsManager.colors.divider.opacity(0.2))
+                        .transition(.opacity)
+                        .animation(.easeInOut, value: selectedCategory)
+                }
+            }
         }
     }
 
@@ -194,7 +198,7 @@ struct RecipesView: View {
             headerView
 
             ScrollView {
-                LazyVGrid(columns: [GridItem(.adaptive(minimum: 320), spacing: 12)], spacing: 12) {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 300), spacing: 20)], spacing: 20) {
                     ForEach(displayedRecipes) { recipe in
                         RecipeCard(
                             recipe: recipe,


### PR DESCRIPTION
## Summary
- redesign `iPadBody` in `ContentView` with a three-column `NavigationSplitView`
- streamline header to remove categories on iPad
- update iPad recipe grid to use larger spacing

## Testing
- `swift test` *(fails: `Could not find Package.swift`)*

------
https://chatgpt.com/codex/tasks/task_e_6841e37308e0832aa22fe2557aa7966f