### PR TITLE
Fix List selection bindings for iOS

### DIFF
--- a/Brewpad/ContentView.swift
+++ b/Brewpad/ContentView.swift
@@ -15,6 +15,20 @@ struct ContentView: View {
     @State private var selectedTab: Tab = .recipes
     @State private var selectedCategory = 0
 
+    private var selectedTabBinding: Binding<Tab?> {
+        Binding<Tab?>(
+            get: { selectedTab },
+            set: { selectedTab = $0 ?? selectedTab }
+        )
+    }
+
+    private var selectedCategoryBinding: Binding<Int?> {
+        Binding<Int?>(
+            get: { selectedCategory },
+            set: { selectedCategory = $0 ?? selectedCategory }
+        )
+    }
+
     enum Tab: Int, CaseIterable, Identifiable {
         case featured, recipes, manage, info, settings
 
@@ -117,7 +131,7 @@ struct ContentView: View {
 
     private var iPadBody: some View {
         NavigationSplitView {
-            List(selection: $selectedTab) {
+            List(selection: selectedTabBinding) {
                 ForEach(Tab.allCases) { tab in
                     Label(tab.title, systemImage: tab.systemImage)
                         .tag(tab)
@@ -126,7 +140,7 @@ struct ContentView: View {
             .navigationSplitViewColumnWidth(200)
         } content: {
             if selectedTab == .recipes {
-                List(selection: $selectedCategory) {
+                List(selection: selectedCategoryBinding) {
                     let categories = ["All"] + Recipe.Category.allCases.map(\.rawValue)
                     ForEach(categories.indices, id: \.self) { index in
                         Text(categories[index])


### PR DESCRIPTION
## Summary
- add helper bindings for optional selection
- apply the optional bindings when using `List` in `NavigationSplitView`

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6841e4adf918832aa9ee30d81108e17d